### PR TITLE
Fix decimal precision error and missing data source description

### DIFF
--- a/internal/provider/datasources/data_source_billing_meter.go
+++ b/internal/provider/datasources/data_source_billing_meter.go
@@ -13,6 +13,7 @@ import (
 // DataSourceBillingMeter returns the data source for reading Stripe stripe_billing_meter
 func DataSourceBillingMeter() *schema.Resource {
 	return &schema.Resource{
+		Description: "Use this data source to retrieve information about an existing Stripe Billing Meter.",
 		ReadContext: dataSourceBillingMeterRead,
 
 		Schema: map[string]*schema.Schema{

--- a/internal/provider/datasources/data_source_billing_meter.go
+++ b/internal/provider/datasources/data_source_billing_meter.go
@@ -13,7 +13,6 @@ import (
 // DataSourceBillingMeter returns the data source for reading Stripe stripe_billing_meter
 func DataSourceBillingMeter() *schema.Resource {
 	return &schema.Resource{
-		Description: "Use this data source to retrieve information about an existing Stripe Billing Meter.",
 		ReadContext: dataSourceBillingMeterRead,
 
 		Schema: map[string]*schema.Schema{

--- a/internal/provider/resources/resource_price.go
+++ b/internal/provider/resources/resource_price.go
@@ -267,9 +267,10 @@ func ResourcePrice() *schema.Resource {
 							Optional:    true,
 						},
 						"flat_amount_decimal": {
-							Type:        schema.TypeString,
-							Description: "Same as `flat_amount`, but accepts a decimal value representing an integer in the minor units of the currency. Only one of `flat_amount` and `flat_amount_decimal` can be set.",
-							Optional:    true,
+							Type:             schema.TypeString,
+							Description:      "Same as `flat_amount`, but accepts a decimal value representing an integer in the minor units of the currency. Only one of `flat_amount` and `flat_amount_decimal` can be set.",
+							Optional:         true,
+							DiffSuppressFunc: suppressDecimalDiff,
 						},
 						"unit_amount": {
 							Type:        schema.TypeInt,

--- a/internal/provider/resources/resource_v2_billing_license_fee.go
+++ b/internal/provider/resources/resource_v2_billing_license_fee.go
@@ -92,10 +92,11 @@ func ResourceV2BillingLicenseFee() *schema.Resource {
 				}, false)),
 			},
 			"unit_amount": {
-				Type:        schema.TypeString,
-				Description: "The per-unit amount to be charged, represented as a decimal string in minor currency units with at most 12 decimal places. Cannot be set if `tiers` is provided.",
-				Optional:    true,
-				Computed:    true,
+				Type:             schema.TypeString,
+				Description:      "The per-unit amount to be charged, represented as a decimal string in minor currency units with at most 12 decimal places. Cannot be set if `tiers` is provided.",
+				Optional:         true,
+				Computed:         true,
+				DiffSuppressFunc: suppressDecimalDiff,
 			},
 			"tiers": {
 				Type:        schema.TypeList,
@@ -104,19 +105,22 @@ func ResourceV2BillingLicenseFee() *schema.Resource {
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"flat_amount": {
-							Type:        schema.TypeString,
-							Description: "Price for the entire tier, represented as a decimal string in minor currency units with at most 12 decimal places.",
-							Optional:    true,
+							Type:             schema.TypeString,
+							Description:      "Price for the entire tier, represented as a decimal string in minor currency units with at most 12 decimal places.",
+							Optional:         true,
+							DiffSuppressFunc: suppressDecimalDiff,
 						},
 						"unit_amount": {
-							Type:        schema.TypeString,
-							Description: "Per-unit price for units included in this tier, represented as a decimal string in minor currency units with at most 12 decimal places.",
-							Optional:    true,
+							Type:             schema.TypeString,
+							Description:      "Per-unit price for units included in this tier, represented as a decimal string in minor currency units with at most 12 decimal places.",
+							Optional:         true,
+							DiffSuppressFunc: suppressDecimalDiff,
 						},
 						"up_to_decimal": {
-							Type:        schema.TypeString,
-							Description: "Up to and including this quantity will be contained in the tier. Only one of `up_to_decimal` and `up_to_inf` may be set.",
-							Optional:    true,
+							Type:             schema.TypeString,
+							Description:      "Up to and including this quantity will be contained in the tier. Only one of `up_to_decimal` and `up_to_inf` may be set.",
+							Optional:         true,
+							DiffSuppressFunc: suppressDecimalDiff,
 						},
 						"up_to_inf": {
 							Type:        schema.TypeString,
@@ -261,13 +265,13 @@ func resourceV2BillingLicenseFeeRead(ctx context.Context, d *schema.ResourceData
 			for i, item := range v2_billing_license_fee.Tiers {
 				itemData := make(map[string]interface{})
 				if item.FlatAmount != "" {
-					itemData["flat_amount"] = item.FlatAmount
+					itemData["flat_amount"] = normalizeDecimalString(item.FlatAmount)
 				}
 				if item.UnitAmount != "" {
-					itemData["unit_amount"] = item.UnitAmount
+					itemData["unit_amount"] = normalizeDecimalString(item.UnitAmount)
 				}
 				if item.UpToDecimal != "" {
-					itemData["up_to_decimal"] = item.UpToDecimal
+					itemData["up_to_decimal"] = normalizeDecimalString(item.UpToDecimal)
 				}
 				if item.UpToInf != "" {
 					itemData["up_to_inf"] = item.UpToInf

--- a/internal/provider/resources/resource_v2_billing_rate_card_rate.go
+++ b/internal/provider/resources/resource_v2_billing_rate_card_rate.go
@@ -56,11 +56,12 @@ func ResourceV2BillingRateCardRate() *schema.Resource {
 				}, false)),
 			},
 			"unit_amount": {
-				Type:        schema.TypeString,
-				Description: "The per-unit amount to be charged, represented as a decimal string in minor currency units with at most 12 decimal places. Cannot be set if `tiers` is provided.",
-				Optional:    true,
-				Computed:    true,
-				ForceNew:    true,
+				Type:             schema.TypeString,
+				Description:      "The per-unit amount to be charged, represented as a decimal string in minor currency units with at most 12 decimal places. Cannot be set if `tiers` is provided.",
+				Optional:         true,
+				Computed:         true,
+				ForceNew:         true,
+				DiffSuppressFunc: suppressDecimalDiff,
 			},
 			"tiers": {
 				Type:        schema.TypeList,
@@ -70,19 +71,22 @@ func ResourceV2BillingRateCardRate() *schema.Resource {
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"flat_amount": {
-							Type:        schema.TypeString,
-							Description: "Price for the entire tier, represented as a decimal string in minor currency units with at most 12 decimal places.",
-							Optional:    true,
+							Type:             schema.TypeString,
+							Description:      "Price for the entire tier, represented as a decimal string in minor currency units with at most 12 decimal places.",
+							Optional:         true,
+							DiffSuppressFunc: suppressDecimalDiff,
 						},
 						"unit_amount": {
-							Type:        schema.TypeString,
-							Description: "Per-unit price for units included in this tier, represented as a decimal string in minor currency units with at most 12 decimal places.",
-							Optional:    true,
+							Type:             schema.TypeString,
+							Description:      "Per-unit price for units included in this tier, represented as a decimal string in minor currency units with at most 12 decimal places.",
+							Optional:         true,
+							DiffSuppressFunc: suppressDecimalDiff,
 						},
 						"up_to_decimal": {
-							Type:        schema.TypeString,
-							Description: "Up to and including this quantity will be contained in the tier. Only one of `up_to_decimal` and `up_to_inf` may be set.",
-							Optional:    true,
+							Type:             schema.TypeString,
+							Description:      "Up to and including this quantity will be contained in the tier. Only one of `up_to_decimal` and `up_to_inf` may be set.",
+							Optional:         true,
+							DiffSuppressFunc: suppressDecimalDiff,
 						},
 						"up_to_inf": {
 							Type:        schema.TypeString,
@@ -201,13 +205,13 @@ func resourceV2BillingRateCardRateRead(ctx context.Context, d *schema.ResourceDa
 			for i, item := range v2_billing_rate_card_rate.Tiers {
 				itemData := make(map[string]interface{})
 				if item.FlatAmount != "" {
-					itemData["flat_amount"] = item.FlatAmount
+					itemData["flat_amount"] = normalizeDecimalString(item.FlatAmount)
 				}
 				if item.UnitAmount != "" {
-					itemData["unit_amount"] = item.UnitAmount
+					itemData["unit_amount"] = normalizeDecimalString(item.UnitAmount)
 				}
 				if item.UpToDecimal != "" {
-					itemData["up_to_decimal"] = item.UpToDecimal
+					itemData["up_to_decimal"] = normalizeDecimalString(item.UpToDecimal)
 				}
 				if item.UpToInf != "" {
 					itemData["up_to_inf"] = item.UpToInf


### PR DESCRIPTION
This PR fixes two minor errors in the provider:

- Decimal Precision: in certain rare cases, the saved precision of a decimal and the value returned from the API was different, leading to superfluous edits. This change resolves that
- The Billing Meter data source was missing a description field which is now added