### PR TITLE
Fix issues related to UBB support

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/hashicorp/terraform-plugin-docs v0.24.0
 	github.com/hashicorp/terraform-plugin-log v0.9.0
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.31.0
-	github.com/stripe/stripe-go/v84 v84.1.0-alpha.4
+	github.com/stripe/stripe-go/v84 v84.5.0-alpha.2
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -182,8 +182,8 @@ github.com/stretchr/testify v1.5.1/go.mod h1:5W2xD1RspED5o8YsWQXVCued0rvSQ+mT+I5
 github.com/stretchr/testify v1.7.2/go.mod h1:R6va5+xMeoiuVRoj+gSkQ7d3FALtqAAGI1FQKckRals=
 github.com/stretchr/testify v1.8.2 h1:+h33VjcLVPDHtOdpUCuF+7gSuG3yGIftsP1YvFihtJ8=
 github.com/stretchr/testify v1.8.2/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
-github.com/stripe/stripe-go/v84 v84.1.0-alpha.4 h1:OaMpIr3c6i3AlxzxRi0g7MGXko6amzjZXPGcwdZklf4=
-github.com/stripe/stripe-go/v84 v84.1.0-alpha.4/go.mod h1:kjXh3OrF4PT16qz7z9Q5yqYAZ1mJmu8g8f4Z1sOHBfc=
+github.com/stripe/stripe-go/v84 v84.5.0-alpha.2 h1:TAIDvgSgKawC9DCWNDEUJYlWeFybIOdtDP2IAQxpjt8=
+github.com/stripe/stripe-go/v84 v84.5.0-alpha.2/go.mod h1:Z4gcKw1zl4geDG2+cjpSaJES9jaohGX6n7FP8/kHIqw=
 github.com/vmihailenco/msgpack v3.3.3+incompatible/go.mod h1:fy3FlTQTDXWkZ7Bh6AcGMlsjHatGryHQYUTf1ShIgkk=
 github.com/vmihailenco/msgpack v4.0.4+incompatible h1:dSLoQfGFAo3F6OoNhwUmLwVgaUXK79GlxNBwueZn0xI=
 github.com/vmihailenco/msgpack v4.0.4+incompatible/go.mod h1:fy3FlTQTDXWkZ7Bh6AcGMlsjHatGryHQYUTf1ShIgkk=

--- a/internal/provider/datasources/data_source_billing_meter.go
+++ b/internal/provider/datasources/data_source_billing_meter.go
@@ -13,6 +13,7 @@ import (
 // DataSourceBillingMeter returns the data source for reading Stripe stripe_billing_meter
 func DataSourceBillingMeter() *schema.Resource {
 	return &schema.Resource{
+		Description: "Use this data source to retrieve information about an existing Stripe Billing Meter.",
 		ReadContext: dataSourceBillingMeterRead,
 
 		Schema: map[string]*schema.Schema{

--- a/internal/provider/datasources/data_source_billing_meter.go
+++ b/internal/provider/datasources/data_source_billing_meter.go
@@ -13,7 +13,6 @@ import (
 // DataSourceBillingMeter returns the data source for reading Stripe stripe_billing_meter
 func DataSourceBillingMeter() *schema.Resource {
 	return &schema.Resource{
-		Description: "Use this data source to retrieve information about an existing Stripe Billing Meter.",
 		ReadContext: dataSourceBillingMeterRead,
 
 		Schema: map[string]*schema.Schema{

--- a/internal/provider/resources/resource_billing_meter.go
+++ b/internal/provider/resources/resource_billing_meter.go
@@ -131,7 +131,7 @@ func ResourceBillingMeter() *schema.Resource {
 		DeleteContext: resourceBillingMeterDelete,
 
 		Importer: &schema.ResourceImporter{
-			StateContext: schema.ImportStatePassthroughContext,
+			StateContext: resourceBillingMeterImportState,
 		},
 	}
 }
@@ -195,6 +195,8 @@ func resourceBillingMeterCreate(ctx context.Context, d *schema.ResourceData, met
 
 func resourceBillingMeterRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var diags diag.Diagnostics
+	importing := ctx.Value("importing") != nil
+	_ = importing
 	tflog.Debug(ctx, "Reading stripe_billing_meter resource", map[string]interface{}{"id": d.Id()})
 	c := meta.(*stripe.Client)
 
@@ -227,7 +229,7 @@ func resourceBillingMeterRead(ctx context.Context, d *schema.ResourceData, meta 
 	if err := d.Set("status", billing_meter.Status); err != nil {
 		diags = append(diags, diag.FromErr(err)...)
 	}
-	if _, ok := d.GetOk("customer_mapping"); ok {
+	if _, ok := d.GetOk("customer_mapping"); importing || ok {
 		if billing_meter.CustomerMapping != nil {
 			nestedData := make(map[string]interface{})
 			nestedData["event_payload_key"] = billing_meter.CustomerMapping.EventPayloadKey
@@ -248,7 +250,7 @@ func resourceBillingMeterRead(ctx context.Context, d *schema.ResourceData, meta 
 			}
 		}
 	}
-	if _, ok := d.GetOk("value_settings"); ok {
+	if _, ok := d.GetOk("value_settings"); importing || ok {
 		if billing_meter.ValueSettings != nil {
 			nestedData := make(map[string]interface{})
 			nestedData["event_payload_key"] = billing_meter.ValueSettings.EventPayloadKey
@@ -301,4 +303,13 @@ func resourceBillingMeterDelete(ctx context.Context, d *schema.ResourceData, met
 	tflog.Info(ctx, "stripe_billing_meter marked as inactive successfully", map[string]interface{}{"id": d.Id()})
 	d.SetId("")
 	return nil
+}
+
+func resourceBillingMeterImportState(ctx context.Context, d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
+	diags := resourceBillingMeterRead(context.WithValue(ctx, "importing", true), d, meta)
+	if diags.HasError() {
+		return nil, fmt.Errorf("%s", diags[0].Summary)
+	}
+
+	return []*schema.ResourceData{d}, nil
 }

--- a/internal/provider/resources/resource_billing_meter.go
+++ b/internal/provider/resources/resource_billing_meter.go
@@ -52,6 +52,11 @@ func ResourceBillingMeter() *schema.Resource {
 					"hour",
 				}, false)),
 			},
+			"status": {
+				Type:        schema.TypeString,
+				Description: "The meter's status.",
+				Computed:    true,
+			},
 			"customer_mapping": {
 				Type:        schema.TypeList,
 				MaxItems:    1,
@@ -217,6 +222,9 @@ func resourceBillingMeterRead(ctx context.Context, d *schema.ResourceData, meta 
 		diags = append(diags, diag.FromErr(err)...)
 	}
 	if err := d.Set("event_time_window", billing_meter.EventTimeWindow); err != nil {
+		diags = append(diags, diag.FromErr(err)...)
+	}
+	if err := d.Set("status", billing_meter.Status); err != nil {
 		diags = append(diags, diag.FromErr(err)...)
 	}
 	if _, ok := d.GetOk("customer_mapping"); ok {

--- a/internal/provider/resources/resource_coupon.go
+++ b/internal/provider/resources/resource_coupon.go
@@ -173,7 +173,7 @@ func ResourceCoupon() *schema.Resource {
 		DeleteContext: resourceCouponDelete,
 
 		Importer: &schema.ResourceImporter{
-			StateContext: schema.ImportStatePassthroughContext,
+			StateContext: resourceCouponImportState,
 		},
 	}
 }
@@ -261,6 +261,8 @@ func resourceCouponCreate(ctx context.Context, d *schema.ResourceData, meta inte
 
 func resourceCouponRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var diags diag.Diagnostics
+	importing := ctx.Value("importing") != nil
+	_ = importing
 	tflog.Debug(ctx, "Reading stripe_coupon resource", map[string]interface{}{"id": d.Id()})
 	c := meta.(*stripe.Client)
 
@@ -329,7 +331,7 @@ func resourceCouponRead(ctx context.Context, d *schema.ResourceData, meta interf
 	if err := d.Set("valid", coupon.Valid); err != nil {
 		diags = append(diags, diag.FromErr(err)...)
 	}
-	if _, ok := d.GetOk("applies_to"); ok {
+	if _, ok := d.GetOk("applies_to"); importing || ok {
 		if coupon.AppliesTo != nil {
 			nestedData := make(map[string]interface{})
 			if len(nestedData) > 0 {
@@ -339,7 +341,7 @@ func resourceCouponRead(ctx context.Context, d *schema.ResourceData, meta interf
 			}
 		}
 	}
-	if _, ok := d.GetOk("script"); ok {
+	if _, ok := d.GetOk("script"); importing || ok {
 		if coupon.Script != nil {
 			nestedData := make(map[string]interface{})
 			nestedData["display_name"] = coupon.Script.DisplayName
@@ -435,4 +437,13 @@ func resourceCouponDelete(ctx context.Context, d *schema.ResourceData, meta inte
 
 	d.SetId("")
 	return nil
+}
+
+func resourceCouponImportState(ctx context.Context, d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
+	diags := resourceCouponRead(context.WithValue(ctx, "importing", true), d, meta)
+	if diags.HasError() {
+		return nil, fmt.Errorf("%s", diags[0].Summary)
+	}
+
+	return []*schema.ResourceData{d}, nil
 }

--- a/internal/provider/resources/resource_coupon.go
+++ b/internal/provider/resources/resource_coupon.go
@@ -108,6 +108,21 @@ func ResourceCoupon() *schema.Resource {
 				Computed:    true,
 				ForceNew:    true,
 			},
+			"times_redeemed": {
+				Type:        schema.TypeInt,
+				Description: "Number of times this coupon has been applied to a customer.",
+				Computed:    true,
+			},
+			"type": {
+				Type:        schema.TypeString,
+				Description: "One of `amount_off`, `percent_off`, or `script`. Describes the type of coupon logic used to calculate the discount.",
+				Computed:    true,
+			},
+			"valid": {
+				Type:        schema.TypeBool,
+				Description: "Taking account of the above properties, whether this coupon can still be applied to a customer.",
+				Computed:    true,
+			},
 			"applies_to": {
 				Type:        schema.TypeList,
 				MaxItems:    1,
@@ -303,6 +318,15 @@ func resourceCouponRead(ctx context.Context, d *schema.ResourceData, meta interf
 		diags = append(diags, diag.FromErr(err)...)
 	}
 	if err := d.Set("redeem_by", coupon.RedeemBy); err != nil {
+		diags = append(diags, diag.FromErr(err)...)
+	}
+	if err := d.Set("times_redeemed", coupon.TimesRedeemed); err != nil {
+		diags = append(diags, diag.FromErr(err)...)
+	}
+	if err := d.Set("type", coupon.Type); err != nil {
+		diags = append(diags, diag.FromErr(err)...)
+	}
+	if err := d.Set("valid", coupon.Valid); err != nil {
 		diags = append(diags, diag.FromErr(err)...)
 	}
 	if _, ok := d.GetOk("applies_to"); ok {

--- a/internal/provider/resources/resource_customer.go
+++ b/internal/provider/resources/resource_customer.go
@@ -353,7 +353,7 @@ func ResourceCustomer() *schema.Resource {
 		DeleteContext: resourceCustomerDelete,
 
 		Importer: &schema.ResourceImporter{
-			StateContext: schema.ImportStatePassthroughContext,
+			StateContext: resourceCustomerImportState,
 		},
 	}
 }
@@ -539,6 +539,8 @@ func resourceCustomerCreate(ctx context.Context, d *schema.ResourceData, meta in
 
 func resourceCustomerRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var diags diag.Diagnostics
+	importing := ctx.Value("importing") != nil
+	_ = importing
 	tflog.Debug(ctx, "Reading stripe_customer resource", map[string]interface{}{"id": d.Id()})
 	c := meta.(*stripe.Client)
 
@@ -604,7 +606,7 @@ func resourceCustomerRead(ctx context.Context, d *schema.ResourceData, meta inte
 	if err := d.Set("delinquent", customer.Delinquent); err != nil {
 		diags = append(diags, diag.FromErr(err)...)
 	}
-	if _, ok := d.GetOk("address"); ok {
+	if _, ok := d.GetOk("address"); importing || ok {
 		if customer.Address != nil {
 			nestedData := make(map[string]interface{})
 			if customer.Address.City != "" {
@@ -632,7 +634,7 @@ func resourceCustomerRead(ctx context.Context, d *schema.ResourceData, meta inte
 			}
 		}
 	}
-	if _, ok := d.GetOk("cash_balance"); ok {
+	if _, ok := d.GetOk("cash_balance"); importing || ok {
 		if customer.CashBalance != nil {
 			nestedData := make(map[string]interface{})
 			if customer.CashBalance.Customer != "" {
@@ -656,7 +658,7 @@ func resourceCustomerRead(ctx context.Context, d *schema.ResourceData, meta inte
 			}
 		}
 	}
-	if _, ok := d.GetOk("invoice_settings"); ok {
+	if _, ok := d.GetOk("invoice_settings"); importing || ok {
 		if customer.InvoiceSettings != nil {
 			nestedData := make(map[string]interface{})
 			if customer.InvoiceSettings.DefaultPaymentMethod != nil {
@@ -682,7 +684,7 @@ func resourceCustomerRead(ctx context.Context, d *schema.ResourceData, meta inte
 			}
 		}
 	}
-	if _, ok := d.GetOk("shipping"); ok {
+	if _, ok := d.GetOk("shipping"); importing || ok {
 		if customer.Shipping != nil {
 			nestedData := make(map[string]interface{})
 			if customer.Shipping.Address != nil {
@@ -726,7 +728,7 @@ func resourceCustomerRead(ctx context.Context, d *schema.ResourceData, meta inte
 			}
 		}
 	}
-	if _, ok := d.GetOk("tax"); ok {
+	if _, ok := d.GetOk("tax"); importing || ok {
 		if customer.Tax != nil {
 			nestedData := make(map[string]interface{})
 			if customer.Tax.AutomaticTax != "" {
@@ -981,4 +983,13 @@ func resourceCustomerDelete(ctx context.Context, d *schema.ResourceData, meta in
 
 	d.SetId("")
 	return nil
+}
+
+func resourceCustomerImportState(ctx context.Context, d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
+	diags := resourceCustomerRead(context.WithValue(ctx, "importing", true), d, meta)
+	if diags.HasError() {
+		return nil, fmt.Errorf("%s", diags[0].Summary)
+	}
+
+	return []*schema.ResourceData{d}, nil
 }

--- a/internal/provider/resources/resource_customer.go
+++ b/internal/provider/resources/resource_customer.go
@@ -111,6 +111,20 @@ func ResourceCustomer() *schema.Resource {
 				Computed:    true,
 				ForceNew:    true,
 			},
+			"currency": {
+				Type:        schema.TypeString,
+				Description: "Three-letter [ISO code for the currency](https://stripe.com/docs/currencies) the customer can be charged in for recurring billing purposes.",
+				Computed:    true,
+			},
+			"customer_account": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"delinquent": {
+				Type:        schema.TypeBool,
+				Description: "Tracks the most recent state change on any invoice belonging to the customer. Paying an invoice or marking it uncollectible via the API will set this field to false. An automatic payment failure or passing the `invoice.due_date` will set this field to `true`. If an invoice becomes uncollectible by [dunning](https://stripe.com/docs/billing/automatic-collection), `delinquent` doesn't reset to `false`. If you care whether the customer has paid their most recent subscription invoice, use `subscription.status` instead. Paying or marking uncollectible any customer invoice regardless of whether it is the latest invoice for a subscription will always set this field to `false`.",
+				Computed:    true,
+			},
 			"address": {
 				Type:     schema.TypeList,
 				MaxItems: 1,
@@ -579,6 +593,15 @@ func resourceCustomerRead(ctx context.Context, d *schema.ResourceData, meta inte
 		diags = append(diags, diag.FromErr(err)...)
 	}
 	if err := d.Set("test_clock", customer.TestClock); err != nil {
+		diags = append(diags, diag.FromErr(err)...)
+	}
+	if err := d.Set("currency", customer.Currency); err != nil {
+		diags = append(diags, diag.FromErr(err)...)
+	}
+	if err := d.Set("customer_account", customer.CustomerAccount); err != nil {
+		diags = append(diags, diag.FromErr(err)...)
+	}
+	if err := d.Set("delinquent", customer.Delinquent); err != nil {
 		diags = append(diags, diag.FromErr(err)...)
 	}
 	if _, ok := d.GetOk("address"); ok {

--- a/internal/provider/resources/resource_customer.go
+++ b/internal/provider/resources/resource_customer.go
@@ -638,6 +638,9 @@ func resourceCustomerRead(ctx context.Context, d *schema.ResourceData, meta inte
 			if customer.CashBalance.Customer != "" {
 				nestedData["customer"] = customer.CashBalance.Customer
 			}
+			if customer.CashBalance.CustomerAccount != "" {
+				nestedData["customer_account"] = customer.CashBalance.CustomerAccount
+			}
 			if customer.CashBalance.Settings != nil {
 				nestedData0 := make(map[string]interface{})
 				if customer.CashBalance.Settings.ReconciliationMode != "" {

--- a/internal/provider/resources/resource_entitlements_feature.go
+++ b/internal/provider/resources/resource_entitlements_feature.go
@@ -40,6 +40,11 @@ func ResourceEntitlementsFeature() *schema.Resource {
 				Description: "The feature's name, for your own purpose, not meant to be displayable to the customer.",
 				Required:    true,
 			},
+			"active": {
+				Type:        schema.TypeBool,
+				Description: "Inactive features cannot be attached to new products and will not be returned from the features list endpoint.",
+				Computed:    true,
+			},
 		},
 
 		CreateContext: resourceEntitlementsFeatureCreate,
@@ -104,6 +109,9 @@ func resourceEntitlementsFeatureRead(ctx context.Context, d *schema.ResourceData
 		diags = append(diags, diag.FromErr(err)...)
 	}
 	if err := d.Set("name", entitlements_feature.Name); err != nil {
+		diags = append(diags, diag.FromErr(err)...)
+	}
+	if err := d.Set("active", entitlements_feature.Active); err != nil {
 		diags = append(diags, diag.FromErr(err)...)
 	}
 	return diags

--- a/internal/provider/resources/resource_entitlements_feature.go
+++ b/internal/provider/resources/resource_entitlements_feature.go
@@ -53,7 +53,7 @@ func ResourceEntitlementsFeature() *schema.Resource {
 		DeleteContext: resourceEntitlementsFeatureDelete,
 
 		Importer: &schema.ResourceImporter{
-			StateContext: schema.ImportStatePassthroughContext,
+			StateContext: resourceEntitlementsFeatureImportState,
 		},
 	}
 }
@@ -87,6 +87,8 @@ func resourceEntitlementsFeatureCreate(ctx context.Context, d *schema.ResourceDa
 
 func resourceEntitlementsFeatureRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var diags diag.Diagnostics
+	importing := ctx.Value("importing") != nil
+	_ = importing
 	tflog.Debug(ctx, "Reading stripe_entitlements_feature resource", map[string]interface{}{"id": d.Id()})
 	c := meta.(*stripe.Client)
 
@@ -176,4 +178,13 @@ func resourceEntitlementsFeatureDelete(ctx context.Context, d *schema.ResourceDa
 		map[string]interface{}{"id": d.Id()})
 	d.SetId("")
 	return nil
+}
+
+func resourceEntitlementsFeatureImportState(ctx context.Context, d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
+	diags := resourceEntitlementsFeatureRead(context.WithValue(ctx, "importing", true), d, meta)
+	if diags.HasError() {
+		return nil, fmt.Errorf("%s", diags[0].Summary)
+	}
+
+	return []*schema.ResourceData{d}, nil
 }

--- a/internal/provider/resources/resource_price.go
+++ b/internal/provider/resources/resource_price.go
@@ -356,7 +356,7 @@ func ResourcePrice() *schema.Resource {
 		DeleteContext: resourcePriceDelete,
 
 		Importer: &schema.ResourceImporter{
-			StateContext: schema.ImportStatePassthroughContext,
+			StateContext: resourcePriceImportState,
 		},
 	}
 }
@@ -510,6 +510,8 @@ func resourcePriceCreate(ctx context.Context, d *schema.ResourceData, meta inter
 
 func resourcePriceRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var diags diag.Diagnostics
+	importing := ctx.Value("importing") != nil
+	_ = importing
 	tflog.Debug(ctx, "Reading stripe_price resource", map[string]interface{}{"id": d.Id()})
 	c := meta.(*stripe.Client)
 
@@ -583,7 +585,7 @@ func resourcePriceRead(ctx context.Context, d *schema.ResourceData, meta interfa
 			diags = append(diags, diag.FromErr(err)...)
 		}
 	}
-	if _, ok := d.GetOk("custom_unit_amount"); ok {
+	if _, ok := d.GetOk("custom_unit_amount"); importing || ok {
 		if price.CustomUnitAmount != nil {
 			nestedData := make(map[string]interface{})
 			nestedData["maximum"] = int(price.CustomUnitAmount.Maximum)
@@ -596,7 +598,7 @@ func resourcePriceRead(ctx context.Context, d *schema.ResourceData, meta interfa
 			}
 		}
 	}
-	if _, ok := d.GetOk("recurring"); ok {
+	if _, ok := d.GetOk("recurring"); importing || ok {
 		if price.Recurring != nil {
 			nestedData := make(map[string]interface{})
 			nestedData["interval"] = price.Recurring.Interval
@@ -611,7 +613,7 @@ func resourcePriceRead(ctx context.Context, d *schema.ResourceData, meta interfa
 			}
 		}
 	}
-	if _, ok := d.GetOk("tiers"); ok {
+	if _, ok := d.GetOk("tiers"); importing || ok {
 		if price.Tiers != nil && len(price.Tiers) > 0 {
 			itemsData := make([]interface{}, len(price.Tiers))
 			for i, item := range price.Tiers {
@@ -737,4 +739,13 @@ func resourcePriceDelete(ctx context.Context, d *schema.ResourceData, meta inter
 	tflog.Info(ctx, "stripe_price marked as inactive successfully", map[string]interface{}{"id": d.Id()})
 	d.SetId("")
 	return nil
+}
+
+func resourcePriceImportState(ctx context.Context, d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
+	diags := resourcePriceRead(context.WithValue(ctx, "importing", true), d, meta)
+	if diags.HasError() {
+		return nil, fmt.Errorf("%s", diags[0].Summary)
+	}
+
+	return []*schema.ResourceData{d}, nil
 }

--- a/internal/provider/resources/resource_price.go
+++ b/internal/provider/resources/resource_price.go
@@ -167,6 +167,11 @@ func ResourcePrice() *schema.Resource {
 				Computed:    true,
 				ForceNew:    true,
 			},
+			"type": {
+				Type:        schema.TypeString,
+				Description: "One of `one_time` or `recurring` depending on whether the price is for a one-time purchase or a recurring (subscription) purchase.",
+				Computed:    true,
+			},
 			"custom_unit_amount": {
 				Type:        schema.TypeList,
 				MaxItems:    1,
@@ -568,6 +573,9 @@ func resourcePriceRead(ctx context.Context, d *schema.ResourceData, meta interfa
 		diags = append(diags, diag.FromErr(err)...)
 	}
 	if err := d.Set("unit_amount", price.UnitAmount); err != nil {
+		diags = append(diags, diag.FromErr(err)...)
+	}
+	if err := d.Set("type", price.Type); err != nil {
 		diags = append(diags, diag.FromErr(err)...)
 	}
 	if price.Product != nil {

--- a/internal/provider/resources/resource_product.go
+++ b/internal/provider/resources/resource_product.go
@@ -326,7 +326,7 @@ func ResourceProduct() *schema.Resource {
 		DeleteContext: resourceProductDelete,
 
 		Importer: &schema.ResourceImporter{
-			StateContext: schema.ImportStatePassthroughContext,
+			StateContext: resourceProductImportState,
 		},
 	}
 }
@@ -471,6 +471,8 @@ func resourceProductCreate(ctx context.Context, d *schema.ResourceData, meta int
 
 func resourceProductRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var diags diag.Diagnostics
+	importing := ctx.Value("importing") != nil
+	_ = importing
 	tflog.Debug(ctx, "Reading stripe_product resource", map[string]interface{}{"id": d.Id()})
 	c := meta.(*stripe.Client)
 
@@ -523,7 +525,7 @@ func resourceProductRead(ctx context.Context, d *schema.ResourceData, meta inter
 			diags = append(diags, diag.FromErr(err)...)
 		}
 	}
-	if _, ok := d.GetOk("package_dimensions"); ok {
+	if _, ok := d.GetOk("package_dimensions"); importing || ok {
 		if product.PackageDimensions != nil {
 			nestedData := make(map[string]interface{})
 			nestedData["height"] = product.PackageDimensions.Height
@@ -537,7 +539,7 @@ func resourceProductRead(ctx context.Context, d *schema.ResourceData, meta inter
 			}
 		}
 	}
-	if _, ok := d.GetOk("marketing_features"); ok {
+	if _, ok := d.GetOk("marketing_features"); importing || ok {
 		if product.MarketingFeatures != nil && len(product.MarketingFeatures) > 0 {
 			itemsData := make([]interface{}, len(product.MarketingFeatures))
 			for i, item := range product.MarketingFeatures {
@@ -697,4 +699,13 @@ func resourceProductDelete(ctx context.Context, d *schema.ResourceData, meta int
 	tflog.Info(ctx, "stripe_product marked as inactive successfully", map[string]interface{}{"id": d.Id()})
 	d.SetId("")
 	return nil
+}
+
+func resourceProductImportState(ctx context.Context, d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
+	diags := resourceProductRead(context.WithValue(ctx, "importing", true), d, meta)
+	if diags.HasError() {
+		return nil, fmt.Errorf("%s", diags[0].Summary)
+	}
+
+	return []*schema.ResourceData{d}, nil
 }

--- a/internal/provider/resources/resource_promotion_code.go
+++ b/internal/provider/resources/resource_promotion_code.go
@@ -160,7 +160,7 @@ func ResourcePromotionCode() *schema.Resource {
 		DeleteContext: resourcePromotionCodeDelete,
 
 		Importer: &schema.ResourceImporter{
-			StateContext: schema.ImportStatePassthroughContext,
+			StateContext: resourcePromotionCodeImportState,
 		},
 	}
 }
@@ -245,6 +245,8 @@ func resourcePromotionCodeCreate(ctx context.Context, d *schema.ResourceData, me
 
 func resourcePromotionCodeRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var diags diag.Diagnostics
+	importing := ctx.Value("importing") != nil
+	_ = importing
 	tflog.Debug(ctx, "Reading stripe_promotion_code resource", map[string]interface{}{"id": d.Id()})
 	c := meta.(*stripe.Client)
 
@@ -296,7 +298,7 @@ func resourcePromotionCodeRead(ctx context.Context, d *schema.ResourceData, meta
 			}
 		}
 	}
-	if _, ok := d.GetOk("restrictions"); ok {
+	if _, ok := d.GetOk("restrictions"); importing || ok {
 		if promotion_code.Restrictions != nil {
 			nestedData := make(map[string]interface{})
 			if promotion_code.Restrictions.CurrencyOptions != nil && len(promotion_code.Restrictions.CurrencyOptions) > 0 {
@@ -416,4 +418,13 @@ func resourcePromotionCodeDelete(ctx context.Context, d *schema.ResourceData, me
 	tflog.Info(ctx, "stripe_promotion_code marked as inactive successfully", map[string]interface{}{"id": d.Id()})
 	d.SetId("")
 	return nil
+}
+
+func resourcePromotionCodeImportState(ctx context.Context, d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
+	diags := resourcePromotionCodeRead(context.WithValue(ctx, "importing", true), d, meta)
+	if diags.HasError() {
+		return nil, fmt.Errorf("%s", diags[0].Summary)
+	}
+
+	return []*schema.ResourceData{d}, nil
 }

--- a/internal/provider/resources/resource_promotion_code.go
+++ b/internal/provider/resources/resource_promotion_code.go
@@ -71,6 +71,11 @@ func ResourcePromotionCode() *schema.Resource {
 				Computed:    true,
 				Elem:        &schema.Schema{Type: schema.TypeString},
 			},
+			"times_redeemed": {
+				Type:        schema.TypeInt,
+				Description: "Number of times this promotion code has been used.",
+				Computed:    true,
+			},
 			"promotion": {
 				Type:        schema.TypeList,
 				MaxItems:    1,
@@ -274,6 +279,9 @@ func resourcePromotionCodeRead(ctx context.Context, d *schema.ResourceData, meta
 		diags = append(diags, diag.FromErr(err)...)
 	}
 	if err := d.Set("metadata", promotion_code.Metadata); err != nil {
+		diags = append(diags, diag.FromErr(err)...)
+	}
+	if err := d.Set("times_redeemed", promotion_code.TimesRedeemed); err != nil {
 		diags = append(diags, diag.FromErr(err)...)
 	}
 	if promotion_code.Promotion != nil {

--- a/internal/provider/resources/resource_shipping_rate.go
+++ b/internal/provider/resources/resource_shipping_rate.go
@@ -193,7 +193,7 @@ func ResourceShippingRate() *schema.Resource {
 		DeleteContext: resourceShippingRateDelete,
 
 		Importer: &schema.ResourceImporter{
-			StateContext: schema.ImportStatePassthroughContext,
+			StateContext: resourceShippingRateImportState,
 		},
 	}
 }
@@ -286,6 +286,8 @@ func resourceShippingRateCreate(ctx context.Context, d *schema.ResourceData, met
 
 func resourceShippingRateRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var diags diag.Diagnostics
+	importing := ctx.Value("importing") != nil
+	_ = importing
 	tflog.Debug(ctx, "Reading stripe_shipping_rate resource", map[string]interface{}{"id": d.Id()})
 	c := meta.(*stripe.Client)
 
@@ -321,7 +323,7 @@ func resourceShippingRateRead(ctx context.Context, d *schema.ResourceData, meta 
 			diags = append(diags, diag.FromErr(err)...)
 		}
 	}
-	if _, ok := d.GetOk("delivery_estimate"); ok {
+	if _, ok := d.GetOk("delivery_estimate"); importing || ok {
 		if shipping_rate.DeliveryEstimate != nil {
 			nestedData := make(map[string]interface{})
 			if shipping_rate.DeliveryEstimate.Maximum != nil {
@@ -343,7 +345,7 @@ func resourceShippingRateRead(ctx context.Context, d *schema.ResourceData, meta 
 			}
 		}
 	}
-	if _, ok := d.GetOk("fixed_amount"); ok {
+	if _, ok := d.GetOk("fixed_amount"); importing || ok {
 		if shipping_rate.FixedAmount != nil {
 			nestedData := make(map[string]interface{})
 			nestedData["amount"] = int(shipping_rate.FixedAmount.Amount)
@@ -470,4 +472,13 @@ func resourceShippingRateDelete(ctx context.Context, d *schema.ResourceData, met
 	tflog.Info(ctx, "stripe_shipping_rate marked as inactive successfully", map[string]interface{}{"id": d.Id()})
 	d.SetId("")
 	return nil
+}
+
+func resourceShippingRateImportState(ctx context.Context, d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
+	diags := resourceShippingRateRead(context.WithValue(ctx, "importing", true), d, meta)
+	if diags.HasError() {
+		return nil, fmt.Errorf("%s", diags[0].Summary)
+	}
+
+	return []*schema.ResourceData{d}, nil
 }

--- a/internal/provider/resources/resource_shipping_rate.go
+++ b/internal/provider/resources/resource_shipping_rate.go
@@ -64,6 +64,11 @@ func ResourceShippingRate() *schema.Resource {
 					"fixed_amount",
 				}, false)),
 			},
+			"active": {
+				Type:        schema.TypeBool,
+				Description: "Whether the shipping rate can be used for new purchases. Defaults to `true`.",
+				Computed:    true,
+			},
 			"delivery_estimate": {
 				Type:        schema.TypeList,
 				MaxItems:    1,
@@ -306,6 +311,9 @@ func resourceShippingRateRead(ctx context.Context, d *schema.ResourceData, meta 
 		diags = append(diags, diag.FromErr(err)...)
 	}
 	if err := d.Set("type", shipping_rate.Type); err != nil {
+		diags = append(diags, diag.FromErr(err)...)
+	}
+	if err := d.Set("active", shipping_rate.Active); err != nil {
 		diags = append(diags, diag.FromErr(err)...)
 	}
 	if shipping_rate.TaxCode != nil {

--- a/internal/provider/resources/resource_tax_rate.go
+++ b/internal/provider/resources/resource_tax_rate.go
@@ -122,7 +122,7 @@ func ResourceTaxRate() *schema.Resource {
 		DeleteContext: resourceTaxRateDelete,
 
 		Importer: &schema.ResourceImporter{
-			StateContext: schema.ImportStatePassthroughContext,
+			StateContext: resourceTaxRateImportState,
 		},
 	}
 }
@@ -173,6 +173,8 @@ func resourceTaxRateCreate(ctx context.Context, d *schema.ResourceData, meta int
 
 func resourceTaxRateRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var diags diag.Diagnostics
+	importing := ctx.Value("importing") != nil
+	_ = importing
 	tflog.Debug(ctx, "Reading stripe_tax_rate resource", map[string]interface{}{"id": d.Id()})
 	c := meta.(*stripe.Client)
 
@@ -326,4 +328,13 @@ func resourceTaxRateDelete(ctx context.Context, d *schema.ResourceData, meta int
 	tflog.Info(ctx, "stripe_tax_rate marked as inactive successfully", map[string]interface{}{"id": d.Id()})
 	d.SetId("")
 	return nil
+}
+
+func resourceTaxRateImportState(ctx context.Context, d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
+	diags := resourceTaxRateRead(context.WithValue(ctx, "importing", true), d, meta)
+	if diags.HasError() {
+		return nil, fmt.Errorf("%s", diags[0].Summary)
+	}
+
+	return []*schema.ResourceData{d}, nil
 }

--- a/internal/provider/resources/resource_tax_rate.go
+++ b/internal/provider/resources/resource_tax_rate.go
@@ -99,6 +99,21 @@ func ResourceTaxRate() *schema.Resource {
 					"vat",
 				}, false)),
 			},
+			"effective_percentage": {
+				Type:        schema.TypeFloat,
+				Description: "Actual/effective tax rate percentage out of 100. For tax calculations with automatic_tax[enabled]=true, this percentage reflects the rate actually used to calculate tax based on the product's taxability and whether the user is registered to collect taxes in the corresponding jurisdiction.",
+				Computed:    true,
+			},
+			"jurisdiction_level": {
+				Type:        schema.TypeString,
+				Description: "The level of the jurisdiction that imposes this tax rate. Will be `null` for manually defined tax rates.",
+				Computed:    true,
+			},
+			"rate_type": {
+				Type:        schema.TypeString,
+				Description: "Indicates the type of tax rate applied to the taxable amount. This value can be `null` when no tax applies to the location. This field is only present for TaxRates created by Stripe Tax.",
+				Computed:    true,
+			},
 		},
 
 		CreateContext: resourceTaxRateCreate,
@@ -201,6 +216,15 @@ func resourceTaxRateRead(ctx context.Context, d *schema.ResourceData, meta inter
 		diags = append(diags, diag.FromErr(err)...)
 	}
 	if err := d.Set("tax_type", tax_rate.TaxType); err != nil {
+		diags = append(diags, diag.FromErr(err)...)
+	}
+	if err := d.Set("effective_percentage", tax_rate.EffectivePercentage); err != nil {
+		diags = append(diags, diag.FromErr(err)...)
+	}
+	if err := d.Set("jurisdiction_level", tax_rate.JurisdictionLevel); err != nil {
+		diags = append(diags, diag.FromErr(err)...)
+	}
+	if err := d.Set("rate_type", tax_rate.RateType); err != nil {
 		diags = append(diags, diag.FromErr(err)...)
 	}
 	return diags

--- a/internal/provider/resources/resource_v2_billing_license_fee.go
+++ b/internal/provider/resources/resource_v2_billing_license_fee.go
@@ -16,7 +16,7 @@ import (
 // ResourceV2BillingLicenseFee returns the schema for the stripe_v2_billing_license_fee resource
 func ResourceV2BillingLicenseFee() *schema.Resource {
 	return &schema.Resource{
-		Description: "Manages a stripe_v2_billing_license_fee resource in Stripe.",
+		Description: "A License Fee represents a versioned recurring charge for a Licensed Item, typically used for seat-based or quantity-based pricing. Each License Fee defines the pricing structure (flat unit amount or tiered pricing) and service interval. After creating a License Fee, you can subscribe customers to it by creating a License Fee Subscription.",
 
 		Schema: map[string]*schema.Schema{
 			"id": {

--- a/internal/provider/resources/resource_v2_billing_license_fee.go
+++ b/internal/provider/resources/resource_v2_billing_license_fee.go
@@ -153,7 +153,7 @@ func ResourceV2BillingLicenseFee() *schema.Resource {
 		DeleteContext: resourceV2BillingLicenseFeeDelete,
 
 		Importer: &schema.ResourceImporter{
-			StateContext: schema.ImportStatePassthroughContext,
+			StateContext: resourceV2BillingLicenseFeeImportState,
 		},
 	}
 }
@@ -227,6 +227,8 @@ func resourceV2BillingLicenseFeeCreate(ctx context.Context, d *schema.ResourceDa
 
 func resourceV2BillingLicenseFeeRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var diags diag.Diagnostics
+	importing := ctx.Value("importing") != nil
+	_ = importing
 	tflog.Debug(ctx, "Reading stripe_v2_billing_license_fee resource", map[string]interface{}{"id": d.Id()})
 	c := meta.(*stripe.Client)
 
@@ -283,7 +285,7 @@ func resourceV2BillingLicenseFeeRead(ctx context.Context, d *schema.ResourceData
 			diags = append(diags, diag.FromErr(err)...)
 		}
 	}
-	if _, ok := d.GetOk("tiers"); ok {
+	if _, ok := d.GetOk("tiers"); importing || ok {
 		if v2_billing_license_fee.Tiers != nil && len(v2_billing_license_fee.Tiers) > 0 {
 			itemsData := make([]interface{}, len(v2_billing_license_fee.Tiers))
 			for i, item := range v2_billing_license_fee.Tiers {
@@ -406,4 +408,13 @@ func resourceV2BillingLicenseFeeDelete(ctx context.Context, d *schema.ResourceDa
 		map[string]interface{}{"id": d.Id()})
 	d.SetId("")
 	return nil
+}
+
+func resourceV2BillingLicenseFeeImportState(ctx context.Context, d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
+	diags := resourceV2BillingLicenseFeeRead(context.WithValue(ctx, "importing", true), d, meta)
+	if diags.HasError() {
+		return nil, fmt.Errorf("%s", diags[0].Summary)
+	}
+
+	return []*schema.ResourceData{d}, nil
 }

--- a/internal/provider/resources/resource_v2_billing_license_fee.go
+++ b/internal/provider/resources/resource_v2_billing_license_fee.go
@@ -98,6 +98,21 @@ func ResourceV2BillingLicenseFee() *schema.Resource {
 				Computed:         true,
 				DiffSuppressFunc: suppressDecimalDiff,
 			},
+			"active": {
+				Type:        schema.TypeBool,
+				Description: "Whether this License Fee is active. Inactive License Fees cannot be used in new activations or be modified.",
+				Computed:    true,
+			},
+			"latest_version": {
+				Type:        schema.TypeString,
+				Description: "The ID of the license fee's most recently created version.",
+				Computed:    true,
+			},
+			"live_version": {
+				Type:        schema.TypeString,
+				Description: "The ID of the License Fee Version that will be used by all subscriptions when no specific version is specified.",
+				Computed:    true,
+			},
 			"tiers": {
 				Type:        schema.TypeList,
 				Optional:    true,
@@ -252,6 +267,15 @@ func resourceV2BillingLicenseFeeRead(ctx context.Context, d *schema.ResourceData
 		diags = append(diags, diag.FromErr(err)...)
 	}
 	if err := d.Set("unit_amount", normalizeDecimalString(v2_billing_license_fee.UnitAmount)); err != nil {
+		diags = append(diags, diag.FromErr(err)...)
+	}
+	if err := d.Set("active", v2_billing_license_fee.Active); err != nil {
+		diags = append(diags, diag.FromErr(err)...)
+	}
+	if err := d.Set("latest_version", v2_billing_license_fee.LatestVersion); err != nil {
+		diags = append(diags, diag.FromErr(err)...)
+	}
+	if err := d.Set("live_version", v2_billing_license_fee.LiveVersion); err != nil {
 		diags = append(diags, diag.FromErr(err)...)
 	}
 	if v2_billing_license_fee.LicensedItem != nil {

--- a/internal/provider/resources/resource_v2_billing_licensed_item.go
+++ b/internal/provider/resources/resource_v2_billing_licensed_item.go
@@ -54,7 +54,7 @@ func ResourceV2BillingLicensedItem() *schema.Resource {
 		DeleteContext: resourceV2BillingLicensedItemDelete,
 
 		Importer: &schema.ResourceImporter{
-			StateContext: schema.ImportStatePassthroughContext,
+			StateContext: resourceV2BillingLicensedItemImportState,
 		},
 	}
 }
@@ -91,6 +91,8 @@ func resourceV2BillingLicensedItemCreate(ctx context.Context, d *schema.Resource
 
 func resourceV2BillingLicensedItemRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var diags diag.Diagnostics
+	importing := ctx.Value("importing") != nil
+	_ = importing
 	tflog.Debug(ctx, "Reading stripe_v2_billing_licensed_item resource", map[string]interface{}{"id": d.Id()})
 	c := meta.(*stripe.Client)
 
@@ -190,4 +192,13 @@ func resourceV2BillingLicensedItemDelete(ctx context.Context, d *schema.Resource
 		map[string]interface{}{"id": d.Id()})
 	d.SetId("")
 	return nil
+}
+
+func resourceV2BillingLicensedItemImportState(ctx context.Context, d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
+	diags := resourceV2BillingLicensedItemRead(context.WithValue(ctx, "importing", true), d, meta)
+	if diags.HasError() {
+		return nil, fmt.Errorf("%s", diags[0].Summary)
+	}
+
+	return []*schema.ResourceData{d}, nil
 }

--- a/internal/provider/resources/resource_v2_billing_metered_item.go
+++ b/internal/provider/resources/resource_v2_billing_metered_item.go
@@ -87,7 +87,7 @@ func ResourceV2BillingMeteredItem() *schema.Resource {
 		DeleteContext: resourceV2BillingMeteredItemDelete,
 
 		Importer: &schema.ResourceImporter{
-			StateContext: schema.ImportStatePassthroughContext,
+			StateContext: resourceV2BillingMeteredItemImportState,
 		},
 	}
 }
@@ -151,6 +151,8 @@ func resourceV2BillingMeteredItemCreate(ctx context.Context, d *schema.ResourceD
 
 func resourceV2BillingMeteredItemRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var diags diag.Diagnostics
+	importing := ctx.Value("importing") != nil
+	_ = importing
 	tflog.Debug(ctx, "Reading stripe_v2_billing_metered_item resource", map[string]interface{}{"id": d.Id()})
 	c := meta.(*stripe.Client)
 
@@ -186,7 +188,7 @@ func resourceV2BillingMeteredItemRead(ctx context.Context, d *schema.ResourceDat
 	if err := d.Set("unit_label", v2_billing_metered_item.UnitLabel); err != nil {
 		diags = append(diags, diag.FromErr(err)...)
 	}
-	if _, ok := d.GetOk("meter_segment_conditions"); ok {
+	if _, ok := d.GetOk("meter_segment_conditions"); importing || ok {
 		if v2_billing_metered_item.MeterSegmentConditions != nil && len(v2_billing_metered_item.MeterSegmentConditions) > 0 {
 			itemsData := make([]interface{}, len(v2_billing_metered_item.MeterSegmentConditions))
 			for i, item := range v2_billing_metered_item.MeterSegmentConditions {
@@ -276,4 +278,13 @@ func resourceV2BillingMeteredItemDelete(ctx context.Context, d *schema.ResourceD
 		map[string]interface{}{"id": d.Id()})
 	d.SetId("")
 	return nil
+}
+
+func resourceV2BillingMeteredItemImportState(ctx context.Context, d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
+	diags := resourceV2BillingMeteredItemRead(context.WithValue(ctx, "importing", true), d, meta)
+	if diags.HasError() {
+		return nil, fmt.Errorf("%s", diags[0].Summary)
+	}
+
+	return []*schema.ResourceData{d}, nil
 }

--- a/internal/provider/resources/resource_v2_billing_pricing_plan.go
+++ b/internal/provider/resources/resource_v2_billing_pricing_plan.go
@@ -16,7 +16,7 @@ import (
 // ResourceV2BillingPricingPlan returns the schema for the stripe_v2_billing_pricing_plan resource
 func ResourceV2BillingPricingPlan() *schema.Resource {
 	return &schema.Resource{
-		Description: "Manages a stripe_v2_billing_pricing_plan resource in Stripe.",
+		Description: "A Pricing Plan represents a bundled collection of billing components that define how customers are charged. Each plan can include multiple components such as Rate Cards for usage-based pricing, License Fees for recurring charges, and Service Actions for recurring credit grants. After creating a Pricing Plan, you can subscribe customers to it by creating a Pricing Plan Subscription.",
 
 		Schema: map[string]*schema.Schema{
 			"id": {

--- a/internal/provider/resources/resource_v2_billing_pricing_plan.go
+++ b/internal/provider/resources/resource_v2_billing_pricing_plan.go
@@ -86,7 +86,7 @@ func ResourceV2BillingPricingPlan() *schema.Resource {
 		DeleteContext: resourceV2BillingPricingPlanDelete,
 
 		Importer: &schema.ResourceImporter{
-			StateContext: schema.ImportStatePassthroughContext,
+			StateContext: resourceV2BillingPricingPlanImportState,
 		},
 	}
 }
@@ -129,6 +129,8 @@ func resourceV2BillingPricingPlanCreate(ctx context.Context, d *schema.ResourceD
 
 func resourceV2BillingPricingPlanRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var diags diag.Diagnostics
+	importing := ctx.Value("importing") != nil
+	_ = importing
 	tflog.Debug(ctx, "Reading stripe_v2_billing_pricing_plan resource", map[string]interface{}{"id": d.Id()})
 	c := meta.(*stripe.Client)
 
@@ -243,4 +245,13 @@ func resourceV2BillingPricingPlanDelete(ctx context.Context, d *schema.ResourceD
 		map[string]interface{}{"id": d.Id()})
 	d.SetId("")
 	return nil
+}
+
+func resourceV2BillingPricingPlanImportState(ctx context.Context, d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
+	diags := resourceV2BillingPricingPlanRead(context.WithValue(ctx, "importing", true), d, meta)
+	if diags.HasError() {
+		return nil, fmt.Errorf("%s", diags[0].Summary)
+	}
+
+	return []*schema.ResourceData{d}, nil
 }

--- a/internal/provider/resources/resource_v2_billing_pricing_plan.go
+++ b/internal/provider/resources/resource_v2_billing_pricing_plan.go
@@ -63,6 +63,21 @@ func ResourceV2BillingPricingPlan() *schema.Resource {
 					"inclusive",
 				}, false)),
 			},
+			"active": {
+				Type:        schema.TypeBool,
+				Description: "Whether the PricingPlan is active.",
+				Computed:    true,
+			},
+			"latest_version": {
+				Type:        schema.TypeString,
+				Description: "The ID of the latest version of the PricingPlan.",
+				Computed:    true,
+			},
+			"live_version": {
+				Type:        schema.TypeString,
+				Description: "The ID of the live version of the PricingPlan.",
+				Computed:    true,
+			},
 		},
 
 		CreateContext: resourceV2BillingPricingPlanCreate,
@@ -145,6 +160,15 @@ func resourceV2BillingPricingPlanRead(ctx context.Context, d *schema.ResourceDat
 		diags = append(diags, diag.FromErr(err)...)
 	}
 	if err := d.Set("tax_behavior", v2_billing_pricing_plan.TaxBehavior); err != nil {
+		diags = append(diags, diag.FromErr(err)...)
+	}
+	if err := d.Set("active", v2_billing_pricing_plan.Active); err != nil {
+		diags = append(diags, diag.FromErr(err)...)
+	}
+	if err := d.Set("latest_version", v2_billing_pricing_plan.LatestVersion); err != nil {
+		diags = append(diags, diag.FromErr(err)...)
+	}
+	if err := d.Set("live_version", v2_billing_pricing_plan.LiveVersion); err != nil {
 		diags = append(diags, diag.FromErr(err)...)
 	}
 	return diags

--- a/internal/provider/resources/resource_v2_billing_pricing_plan_component.go
+++ b/internal/provider/resources/resource_v2_billing_pricing_plan_component.go
@@ -239,6 +239,7 @@ func resourceV2BillingPricingPlanComponentRead(ctx context.Context, d *schema.Re
 	if _, ok := d.GetOk("license_fee"); ok {
 		if v2_billing_pricing_plan_component.LicenseFee != nil {
 			nestedData := make(map[string]interface{})
+			nestedData["id"] = v2_billing_pricing_plan_component.LicenseFee.ID
 			nestedData["version"] = v2_billing_pricing_plan_component.LicenseFee.Version
 			if len(nestedData) > 0 {
 				if err := d.Set("license_fee", []interface{}{nestedData}); err != nil {
@@ -250,6 +251,7 @@ func resourceV2BillingPricingPlanComponentRead(ctx context.Context, d *schema.Re
 	if _, ok := d.GetOk("rate_card"); ok {
 		if v2_billing_pricing_plan_component.RateCard != nil {
 			nestedData := make(map[string]interface{})
+			nestedData["id"] = v2_billing_pricing_plan_component.RateCard.ID
 			nestedData["version"] = v2_billing_pricing_plan_component.RateCard.Version
 			if len(nestedData) > 0 {
 				if err := d.Set("rate_card", []interface{}{nestedData}); err != nil {
@@ -261,6 +263,7 @@ func resourceV2BillingPricingPlanComponentRead(ctx context.Context, d *schema.Re
 	if _, ok := d.GetOk("service_action"); ok {
 		if v2_billing_pricing_plan_component.ServiceAction != nil {
 			nestedData := make(map[string]interface{})
+			nestedData["id"] = v2_billing_pricing_plan_component.ServiceAction.ID
 			if len(nestedData) > 0 {
 				if err := d.Set("service_action", []interface{}{nestedData}); err != nil {
 					diags = append(diags, diag.FromErr(err)...)

--- a/internal/provider/resources/resource_v2_billing_pricing_plan_component.go
+++ b/internal/provider/resources/resource_v2_billing_pricing_plan_component.go
@@ -5,6 +5,7 @@ package resources
 import (
 	"context"
 	"fmt"
+	"strings"
 
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
@@ -136,7 +137,7 @@ func ResourceV2BillingPricingPlanComponent() *schema.Resource {
 		DeleteContext: resourceV2BillingPricingPlanComponentDelete,
 
 		Importer: &schema.ResourceImporter{
-			StateContext: schema.ImportStatePassthroughContext,
+			StateContext: resourceV2BillingPricingPlanComponentImportState,
 		},
 	}
 }
@@ -201,6 +202,8 @@ func resourceV2BillingPricingPlanComponentCreate(ctx context.Context, d *schema.
 
 func resourceV2BillingPricingPlanComponentRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var diags diag.Diagnostics
+	importing := ctx.Value("importing") != nil
+	_ = importing
 	tflog.Debug(ctx, "Reading stripe_v2_billing_pricing_plan_component resource", map[string]interface{}{"id": d.Id()})
 	c := meta.(*stripe.Client)
 
@@ -236,7 +239,7 @@ func resourceV2BillingPricingPlanComponentRead(ctx context.Context, d *schema.Re
 	if err := d.Set("pricing_plan_version", v2_billing_pricing_plan_component.PricingPlanVersion); err != nil {
 		diags = append(diags, diag.FromErr(err)...)
 	}
-	if _, ok := d.GetOk("license_fee"); ok {
+	if _, ok := d.GetOk("license_fee"); importing || ok {
 		if v2_billing_pricing_plan_component.LicenseFee != nil {
 			nestedData := make(map[string]interface{})
 			nestedData["id"] = v2_billing_pricing_plan_component.LicenseFee.ID
@@ -248,7 +251,7 @@ func resourceV2BillingPricingPlanComponentRead(ctx context.Context, d *schema.Re
 			}
 		}
 	}
-	if _, ok := d.GetOk("rate_card"); ok {
+	if _, ok := d.GetOk("rate_card"); importing || ok {
 		if v2_billing_pricing_plan_component.RateCard != nil {
 			nestedData := make(map[string]interface{})
 			nestedData["id"] = v2_billing_pricing_plan_component.RateCard.ID
@@ -260,7 +263,7 @@ func resourceV2BillingPricingPlanComponentRead(ctx context.Context, d *schema.Re
 			}
 		}
 	}
-	if _, ok := d.GetOk("service_action"); ok {
+	if _, ok := d.GetOk("service_action"); importing || ok {
 		if v2_billing_pricing_plan_component.ServiceAction != nil {
 			nestedData := make(map[string]interface{})
 			nestedData["id"] = v2_billing_pricing_plan_component.ServiceAction.ID
@@ -346,4 +349,21 @@ func resourceV2BillingPricingPlanComponentDelete(ctx context.Context, d *schema.
 
 	d.SetId("")
 	return nil
+}
+
+func resourceV2BillingPricingPlanComponentImportState(ctx context.Context, d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
+	parts := strings.SplitN(d.Id(), "/", 2)
+	if len(parts) != 2 {
+		return nil, fmt.Errorf("import ID must be {pricing_plan_id}/{id}, got: %s", d.Id())
+	}
+
+	d.Set("pricing_plan_id", parts[0])
+	d.SetId(parts[1])
+
+	diags := resourceV2BillingPricingPlanComponentRead(context.WithValue(ctx, "importing", true), d, meta)
+	if diags.HasError() {
+		return nil, fmt.Errorf("%s", diags[0].Summary)
+	}
+
+	return []*schema.ResourceData{d}, nil
 }

--- a/internal/provider/resources/resource_v2_billing_pricing_plan_component.go
+++ b/internal/provider/resources/resource_v2_billing_pricing_plan_component.go
@@ -17,7 +17,7 @@ import (
 // ResourceV2BillingPricingPlanComponent returns the schema for the stripe_v2_billing_pricing_plan_component resource
 func ResourceV2BillingPricingPlanComponent() *schema.Resource {
 	return &schema.Resource{
-		Description: "Manages a stripe_v2_billing_pricing_plan_component resource in Stripe.",
+		Description: "A Pricing Plan Component represents an individual billing element within a Pricing Plan. Components can be Rate Cards for usage-based charges, License Fees for recurring fixed charges, or Service Actions for recurring credit grants. Each component is associated with a specific version of the Pricing Plan and defines one aspect of how customers are billed.",
 
 		Schema: map[string]*schema.Schema{
 			"id": {
@@ -80,7 +80,7 @@ func ResourceV2BillingPricingPlanComponent() *schema.Resource {
 						},
 						"version": {
 							Type:        schema.TypeString,
-							Description: "The ID of the License Fee Version. Defaults to 'latest', if not specified.",
+							Description: "The version of the LicenseFee. Defaults to 'latest', if not specified.",
 							Optional:    true,
 							Computed:    true,
 							ForceNew:    true,
@@ -104,7 +104,7 @@ func ResourceV2BillingPricingPlanComponent() *schema.Resource {
 						},
 						"version": {
 							Type:        schema.TypeString,
-							Description: "The ID of the Rate Card Version. Defaults to 'latest', if not specified.",
+							Description: "The version of the RateCard. Defaults to 'latest', if not specified.",
 							Optional:    true,
 							Computed:    true,
 							ForceNew:    true,

--- a/internal/provider/resources/resource_v2_billing_pricing_plan_component.go
+++ b/internal/provider/resources/resource_v2_billing_pricing_plan_component.go
@@ -53,6 +53,16 @@ func ResourceV2BillingPricingPlanComponent() *schema.Resource {
 					"service_action",
 				}, false)),
 			},
+			"pricing_plan": {
+				Type:        schema.TypeString,
+				Description: "The ID of the Pricing Plan this component belongs to.",
+				Computed:    true,
+			},
+			"pricing_plan_version": {
+				Type:        schema.TypeString,
+				Description: "The ID of the Pricing Plan Version this component belongs to.",
+				Computed:    true,
+			},
 			"license_fee": {
 				Type:        schema.TypeList,
 				MaxItems:    1,
@@ -218,6 +228,12 @@ func resourceV2BillingPricingPlanComponentRead(ctx context.Context, d *schema.Re
 		diags = append(diags, diag.FromErr(err)...)
 	}
 	if err := d.Set("type", v2_billing_pricing_plan_component.Type); err != nil {
+		diags = append(diags, diag.FromErr(err)...)
+	}
+	if err := d.Set("pricing_plan", v2_billing_pricing_plan_component.PricingPlan); err != nil {
+		diags = append(diags, diag.FromErr(err)...)
+	}
+	if err := d.Set("pricing_plan_version", v2_billing_pricing_plan_component.PricingPlanVersion); err != nil {
 		diags = append(diags, diag.FromErr(err)...)
 	}
 	if _, ok := d.GetOk("license_fee"); ok {

--- a/internal/provider/resources/resource_v2_billing_rate_card.go
+++ b/internal/provider/resources/resource_v2_billing_rate_card.go
@@ -75,6 +75,21 @@ func ResourceV2BillingRateCard() *schema.Resource {
 					"inclusive",
 				}, false)),
 			},
+			"active": {
+				Type:        schema.TypeBool,
+				Description: "Whether this RateCard is active. Inactive RateCards cannot be used in new activations or have new rates added.",
+				Computed:    true,
+			},
+			"latest_version": {
+				Type:        schema.TypeString,
+				Description: "The ID of this rate card's most recently created version.",
+				Computed:    true,
+			},
+			"live_version": {
+				Type:        schema.TypeString,
+				Description: "The ID of the Rate Card Version that will be used by all subscriptions when no specific version is specified.",
+				Computed:    true,
+			},
 		},
 
 		CreateContext: resourceV2BillingRateCardCreate,
@@ -161,6 +176,15 @@ func resourceV2BillingRateCardRead(ctx context.Context, d *schema.ResourceData, 
 		diags = append(diags, diag.FromErr(err)...)
 	}
 	if err := d.Set("tax_behavior", v2_billing_rate_card.TaxBehavior); err != nil {
+		diags = append(diags, diag.FromErr(err)...)
+	}
+	if err := d.Set("active", v2_billing_rate_card.Active); err != nil {
+		diags = append(diags, diag.FromErr(err)...)
+	}
+	if err := d.Set("latest_version", v2_billing_rate_card.LatestVersion); err != nil {
+		diags = append(diags, diag.FromErr(err)...)
+	}
+	if err := d.Set("live_version", v2_billing_rate_card.LiveVersion); err != nil {
 		diags = append(diags, diag.FromErr(err)...)
 	}
 	return diags

--- a/internal/provider/resources/resource_v2_billing_rate_card.go
+++ b/internal/provider/resources/resource_v2_billing_rate_card.go
@@ -98,7 +98,7 @@ func ResourceV2BillingRateCard() *schema.Resource {
 		DeleteContext: resourceV2BillingRateCardDelete,
 
 		Importer: &schema.ResourceImporter{
-			StateContext: schema.ImportStatePassthroughContext,
+			StateContext: resourceV2BillingRateCardImportState,
 		},
 	}
 }
@@ -142,6 +142,8 @@ func resourceV2BillingRateCardCreate(ctx context.Context, d *schema.ResourceData
 
 func resourceV2BillingRateCardRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var diags diag.Diagnostics
+	importing := ctx.Value("importing") != nil
+	_ = importing
 	tflog.Debug(ctx, "Reading stripe_v2_billing_rate_card resource", map[string]interface{}{"id": d.Id()})
 	c := meta.(*stripe.Client)
 
@@ -254,4 +256,13 @@ func resourceV2BillingRateCardDelete(ctx context.Context, d *schema.ResourceData
 		map[string]interface{}{"id": d.Id()})
 	d.SetId("")
 	return nil
+}
+
+func resourceV2BillingRateCardImportState(ctx context.Context, d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
+	diags := resourceV2BillingRateCardRead(context.WithValue(ctx, "importing", true), d, meta)
+	if diags.HasError() {
+		return nil, fmt.Errorf("%s", diags[0].Summary)
+	}
+
+	return []*schema.ResourceData{d}, nil
 }

--- a/internal/provider/resources/resource_v2_billing_rate_card_rate.go
+++ b/internal/provider/resources/resource_v2_billing_rate_card_rate.go
@@ -63,6 +63,16 @@ func ResourceV2BillingRateCardRate() *schema.Resource {
 				ForceNew:         true,
 				DiffSuppressFunc: suppressDecimalDiff,
 			},
+			"rate_card": {
+				Type:        schema.TypeString,
+				Description: "The ID of the Rate Card it belongs to.",
+				Computed:    true,
+			},
+			"rate_card_version": {
+				Type:        schema.TypeString,
+				Description: "The ID of the Rate Card Version it was created on.",
+				Computed:    true,
+			},
 			"tiers": {
 				Type:        schema.TypeList,
 				Optional:    true,
@@ -192,6 +202,12 @@ func resourceV2BillingRateCardRateRead(ctx context.Context, d *schema.ResourceDa
 		diags = append(diags, diag.FromErr(err)...)
 	}
 	if err := d.Set("unit_amount", normalizeDecimalString(v2_billing_rate_card_rate.UnitAmount)); err != nil {
+		diags = append(diags, diag.FromErr(err)...)
+	}
+	if err := d.Set("rate_card", v2_billing_rate_card_rate.RateCard); err != nil {
+		diags = append(diags, diag.FromErr(err)...)
+	}
+	if err := d.Set("rate_card_version", v2_billing_rate_card_rate.RateCardVersion); err != nil {
 		diags = append(diags, diag.FromErr(err)...)
 	}
 	if v2_billing_rate_card_rate.MeteredItem != nil {

--- a/internal/provider/resources/resource_v2_billing_rate_card_rate.go
+++ b/internal/provider/resources/resource_v2_billing_rate_card_rate.go
@@ -5,6 +5,7 @@ package resources
 import (
 	"context"
 	"fmt"
+	"strings"
 
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
@@ -113,7 +114,7 @@ func ResourceV2BillingRateCardRate() *schema.Resource {
 		DeleteContext: resourceV2BillingRateCardRateDelete,
 
 		Importer: &schema.ResourceImporter{
-			StateContext: schema.ImportStatePassthroughContext,
+			StateContext: resourceV2BillingRateCardRateImportState,
 		},
 	}
 }
@@ -175,6 +176,8 @@ func resourceV2BillingRateCardRateCreate(ctx context.Context, d *schema.Resource
 
 func resourceV2BillingRateCardRateRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var diags diag.Diagnostics
+	importing := ctx.Value("importing") != nil
+	_ = importing
 	tflog.Debug(ctx, "Reading stripe_v2_billing_rate_card_rate resource", map[string]interface{}{"id": d.Id()})
 	c := meta.(*stripe.Client)
 
@@ -215,7 +218,7 @@ func resourceV2BillingRateCardRateRead(ctx context.Context, d *schema.ResourceDa
 			diags = append(diags, diag.FromErr(err)...)
 		}
 	}
-	if _, ok := d.GetOk("tiers"); ok {
+	if _, ok := d.GetOk("tiers"); importing || ok {
 		if v2_billing_rate_card_rate.Tiers != nil && len(v2_billing_rate_card_rate.Tiers) > 0 {
 			itemsData := make([]interface{}, len(v2_billing_rate_card_rate.Tiers))
 			for i, item := range v2_billing_rate_card_rate.Tiers {
@@ -258,4 +261,21 @@ func resourceV2BillingRateCardRateDelete(ctx context.Context, d *schema.Resource
 
 	d.SetId("")
 	return nil
+}
+
+func resourceV2BillingRateCardRateImportState(ctx context.Context, d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
+	parts := strings.SplitN(d.Id(), "/", 2)
+	if len(parts) != 2 {
+		return nil, fmt.Errorf("import ID must be {rate_card_id}/{id}, got: %s", d.Id())
+	}
+
+	d.Set("rate_card_id", parts[0])
+	d.SetId(parts[1])
+
+	diags := resourceV2BillingRateCardRateRead(context.WithValue(ctx, "importing", true), d, meta)
+	if diags.HasError() {
+		return nil, fmt.Errorf("%s", diags[0].Summary)
+	}
+
+	return []*schema.ResourceData{d}, nil
 }

--- a/internal/provider/resources/resource_v2_billing_rate_card_rate.go
+++ b/internal/provider/resources/resource_v2_billing_rate_card_rate.go
@@ -17,7 +17,7 @@ import (
 // ResourceV2BillingRateCardRate returns the schema for the stripe_v2_billing_rate_card_rate resource
 func ResourceV2BillingRateCardRate() *schema.Resource {
 	return &schema.Resource{
-		Description: "Manages a stripe_v2_billing_rate_card_rate resource in Stripe.",
+		Description: "A Rate Card Rate represents a single usage-based price within a Rate Card. Each rate binds to one Metered Item and defines the pricing structure for that item, including either a flat unit amount or tiered pricing. Rates support features like graduated or volume-based tiering, quantity transformations, and custom pricing units.",
 
 		Schema: map[string]*schema.Schema{
 			"id": {
@@ -41,13 +41,12 @@ func ResourceV2BillingRateCardRate() *schema.Resource {
 			"metered_item": {
 				Type:        schema.TypeString,
 				Description: "The Metered Item that this rate binds to.",
-				Optional:    true,
-				Computed:    true,
+				Required:    true,
 				ForceNew:    true,
 			},
 			"tiering_mode": {
 				Type:        schema.TypeString,
-				Description: "Defines whether the tiered price should be graduated or volume-based. In volume-based tiering, the maximum quantity within a period determines the per-unit price. In graduated tiering, the pricing changes as the quantity grows into new tiers. Can only be set if `tiers` is set.",
+				Description: "Defines whether the tiered price should be graduated or volume-based. In volume-based tiering, the maximum quantity within a period determines the per-unit price. In graduated tiering, the pricing changes as the quantity grows into new tiers. One of `unit_amount`, `tiers`, or `custom_pricing_unit_amount` is required.",
 				Optional:    true,
 				Computed:    true,
 				ForceNew:    true,
@@ -58,7 +57,7 @@ func ResourceV2BillingRateCardRate() *schema.Resource {
 			},
 			"unit_amount": {
 				Type:             schema.TypeString,
-				Description:      "The per-unit amount to be charged, represented as a decimal string in minor currency units with at most 12 decimal places. Cannot be set if `tiers` is provided.",
+				Description:      "The per-unit amount to be charged, represented as a decimal string in minor currency units with at most 12 decimal places. One of `unit_amount`, `tiers`, or `custom_pricing_unit_amount` is required.",
 				Optional:         true,
 				Computed:         true,
 				ForceNew:         true,
@@ -78,7 +77,7 @@ func ResourceV2BillingRateCardRate() *schema.Resource {
 				Type:        schema.TypeList,
 				Optional:    true,
 				ForceNew:    true,
-				Description: "Each element represents a pricing tier. Cannot be set if `unit_amount` is provided.",
+				Description: "Each element represents a pricing tier. One of `unit_amount`, `tiers`, or `custom_pricing_unit_amount` is required.",
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"flat_amount": {

--- a/internal/provider/resources/resource_v2_billing_service_action.go
+++ b/internal/provider/resources/resource_v2_billing_service_action.go
@@ -16,7 +16,7 @@ import (
 // ResourceV2BillingServiceAction returns the schema for the stripe_v2_billing_service_action resource
 func ResourceV2BillingServiceAction() *schema.Resource {
 	return &schema.Resource{
-		Description: "Manages a stripe_v2_billing_service_action resource in Stripe.",
+		Description: "Service Actions represent actions applied during service assessment periods, such as granting credits to a customer.",
 
 		Schema: map[string]*schema.Schema{
 			"id": {
@@ -98,15 +98,15 @@ func ResourceV2BillingServiceAction() *schema.Resource {
 										Description: "The monetary amount of the credit grant. Required if `type` is `monetary`.",
 										Elem: &schema.Resource{
 											Schema: map[string]*schema.Schema{
-												"amount": {
-													Type:        schema.TypeInt,
-													Description: "A non-negative integer representing how much to charge in the [smallest currency unit](https://docs.stripe.com/currencies#minor-units).",
-													Optional:    true,
-												},
 												"currency": {
 													Type:        schema.TypeString,
 													Description: "Three-letter [ISO currency code](https://www.iso.org/iso-4217-currency-codes.html), in lowercase. Must be a [supported currency](https://stripe.com/docs/currencies).",
-													Optional:    true,
+													Required:    true,
+												},
+												"value": {
+													Type:        schema.TypeInt,
+													Description: "A non-negative integer representing how much to charge in the [smallest currency unit](https://docs.stripe.com/currencies#minor-units).",
+													Required:    true,
 												},
 											},
 										},
@@ -249,11 +249,11 @@ func resourceV2BillingServiceActionCreate(ctx context.Context, d *schema.Resourc
 			if v, ok := nestedData0["monetary"].([]interface{}); ok && len(v) > 0 {
 				nestedData1 := v[0].(map[string]interface{})
 				params.CreditGrant.Amount.Monetary = &stripe.V2BillingServiceActionCreateCreditGrantAmountMonetaryParams{}
-				if val, ok := nestedData1["amount"].(int); ok && val > 0 {
-					params.CreditGrant.Amount.Monetary.Value = stripe.Int64(int64(val))
-				}
 				if val, ok := nestedData1["currency"].(string); ok && val != "" {
 					params.CreditGrant.Amount.Monetary.Currency = stripe.String(val)
+				}
+				if val, ok := nestedData1["value"].(int); ok {
+					params.CreditGrant.Amount.Monetary.Value = stripe.Int64(int64(val))
 				}
 			}
 			if val, ok := nestedData0["type"].(string); ok && val != "" {
@@ -368,10 +368,10 @@ func resourceV2BillingServiceActionRead(ctx context.Context, d *schema.ResourceD
 				}
 				if v2_billing_service_action.CreditGrant.Amount.Monetary != nil {
 					nestedData1 := make(map[string]interface{})
-					nestedData1["amount"] = int(v2_billing_service_action.CreditGrant.Amount.Monetary.Value)
 					if v2_billing_service_action.CreditGrant.Amount.Monetary.Currency != "" {
 						nestedData1["currency"] = v2_billing_service_action.CreditGrant.Amount.Monetary.Currency
 					}
+					nestedData1["value"] = int(v2_billing_service_action.CreditGrant.Amount.Monetary.Value)
 					nestedData0["monetary"] = []interface{}{nestedData1}
 				}
 				if v2_billing_service_action.CreditGrant.Amount.Type != "" {

--- a/internal/provider/resources/resource_v2_billing_service_action.go
+++ b/internal/provider/resources/resource_v2_billing_service_action.go
@@ -209,7 +209,7 @@ func ResourceV2BillingServiceAction() *schema.Resource {
 		DeleteContext: resourceV2BillingServiceActionDelete,
 
 		Importer: &schema.ResourceImporter{
-			StateContext: schema.ImportStatePassthroughContext,
+			StateContext: resourceV2BillingServiceActionImportState,
 		},
 	}
 }
@@ -308,6 +308,8 @@ func resourceV2BillingServiceActionCreate(ctx context.Context, d *schema.Resourc
 
 func resourceV2BillingServiceActionRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var diags diag.Diagnostics
+	importing := ctx.Value("importing") != nil
+	_ = importing
 	tflog.Debug(ctx, "Reading stripe_v2_billing_service_action resource", map[string]interface{}{"id": d.Id()})
 	c := meta.(*stripe.Client)
 
@@ -335,7 +337,7 @@ func resourceV2BillingServiceActionRead(ctx context.Context, d *schema.ResourceD
 	if err := d.Set("type", v2_billing_service_action.Type); err != nil {
 		diags = append(diags, diag.FromErr(err)...)
 	}
-	if _, ok := d.GetOk("credit_grant"); ok {
+	if _, ok := d.GetOk("credit_grant"); importing || ok {
 		if v2_billing_service_action.CreditGrant != nil {
 			nestedData := make(map[string]interface{})
 			if v2_billing_service_action.CreditGrant.Amount != nil {
@@ -453,4 +455,13 @@ func resourceV2BillingServiceActionDelete(ctx context.Context, d *schema.Resourc
 		map[string]interface{}{"id": d.Id()})
 	d.SetId("")
 	return nil
+}
+
+func resourceV2BillingServiceActionImportState(ctx context.Context, d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
+	diags := resourceV2BillingServiceActionRead(context.WithValue(ctx, "importing", true), d, meta)
+	if diags.HasError() {
+		return nil, fmt.Errorf("%s", diags[0].Summary)
+	}
+
+	return []*schema.ResourceData{d}, nil
 }

--- a/internal/provider/resources/resource_v2_billing_service_action.go
+++ b/internal/provider/resources/resource_v2_billing_service_action.go
@@ -348,10 +348,16 @@ func resourceV2BillingServiceActionRead(ctx context.Context, d *schema.ResourceD
 						if v2_billing_service_action.CreditGrant.Amount.CustomPricingUnit.CustomPricingUnitDetails.DisplayName != "" {
 							nestedData2["display_name"] = v2_billing_service_action.CreditGrant.Amount.CustomPricingUnit.CustomPricingUnitDetails.DisplayName
 						}
+						if v2_billing_service_action.CreditGrant.Amount.CustomPricingUnit.CustomPricingUnitDetails.ID != "" {
+							nestedData2["id"] = v2_billing_service_action.CreditGrant.Amount.CustomPricingUnit.CustomPricingUnitDetails.ID
+						}
 						if v2_billing_service_action.CreditGrant.Amount.CustomPricingUnit.CustomPricingUnitDetails.LookupKey != "" {
 							nestedData2["lookup_key"] = v2_billing_service_action.CreditGrant.Amount.CustomPricingUnit.CustomPricingUnitDetails.LookupKey
 						}
 						nestedData1["custom_pricing_unit_details"] = []interface{}{nestedData2}
+					}
+					if v2_billing_service_action.CreditGrant.Amount.CustomPricingUnit.ID != "" {
+						nestedData1["id"] = v2_billing_service_action.CreditGrant.Amount.CustomPricingUnit.ID
 					}
 					if v2_billing_service_action.CreditGrant.Amount.CustomPricingUnit.Value != "" {
 						nestedData1["value"] = normalizeDecimalString(v2_billing_service_action.CreditGrant.Amount.CustomPricingUnit.Value)

--- a/internal/provider/resources/resource_v2_core_event_destination.go
+++ b/internal/provider/resources/resource_v2_core_event_destination.go
@@ -133,7 +133,7 @@ func ResourceV2CoreEventDestination() *schema.Resource {
 		DeleteContext: resourceV2CoreEventDestinationDelete,
 
 		Importer: &schema.ResourceImporter{
-			StateContext: schema.ImportStatePassthroughContext,
+			StateContext: resourceV2CoreEventDestinationImportState,
 		},
 	}
 }
@@ -211,6 +211,8 @@ func resourceV2CoreEventDestinationCreate(ctx context.Context, d *schema.Resourc
 
 func resourceV2CoreEventDestinationRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var diags diag.Diagnostics
+	importing := ctx.Value("importing") != nil
+	_ = importing
 	tflog.Debug(ctx, "Reading stripe_v2_core_event_destination resource", map[string]interface{}{"id": d.Id()})
 	c := meta.(*stripe.Client)
 
@@ -262,7 +264,7 @@ func resourceV2CoreEventDestinationRead(ctx context.Context, d *schema.ResourceD
 	if err := d.Set("status", v2_core_event_destination.Status); err != nil {
 		diags = append(diags, diag.FromErr(err)...)
 	}
-	if _, ok := d.GetOk("amazon_eventbridge"); ok {
+	if _, ok := d.GetOk("amazon_eventbridge"); importing || ok {
 		if v2_core_event_destination.AmazonEventbridge != nil {
 			nestedData := make(map[string]interface{})
 			nestedData["aws_account_id"] = v2_core_event_destination.AmazonEventbridge.AwsAccountID
@@ -275,7 +277,7 @@ func resourceV2CoreEventDestinationRead(ctx context.Context, d *schema.ResourceD
 			}
 		}
 	}
-	if _, ok := d.GetOk("webhook_endpoint"); ok {
+	if _, ok := d.GetOk("webhook_endpoint"); importing || ok {
 		if v2_core_event_destination.WebhookEndpoint != nil {
 			nestedData := make(map[string]interface{})
 			if v2_core_event_destination.WebhookEndpoint.SigningSecret != "" {
@@ -382,4 +384,13 @@ func resourceV2CoreEventDestinationDelete(ctx context.Context, d *schema.Resourc
 
 	d.SetId("")
 	return nil
+}
+
+func resourceV2CoreEventDestinationImportState(ctx context.Context, d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
+	diags := resourceV2CoreEventDestinationRead(context.WithValue(ctx, "importing", true), d, meta)
+	if diags.HasError() {
+		return nil, fmt.Errorf("%s", diags[0].Summary)
+	}
+
+	return []*schema.ResourceData{d}, nil
 }

--- a/internal/provider/resources/resource_v2_core_event_destination.go
+++ b/internal/provider/resources/resource_v2_core_event_destination.go
@@ -82,6 +82,11 @@ func ResourceV2CoreEventDestination() *schema.Resource {
 					"webhook_endpoint",
 				}, false)),
 			},
+			"status": {
+				Type:        schema.TypeString,
+				Description: "Status. It can be set to either enabled or disabled.",
+				Computed:    true,
+			},
 			"amazon_eventbridge": {
 				Type:        schema.TypeList,
 				MaxItems:    1,
@@ -252,6 +257,9 @@ func resourceV2CoreEventDestinationRead(ctx context.Context, d *schema.ResourceD
 		diags = append(diags, diag.FromErr(err)...)
 	}
 	if err := d.Set("type", v2_core_event_destination.Type); err != nil {
+		diags = append(diags, diag.FromErr(err)...)
+	}
+	if err := d.Set("status", v2_core_event_destination.Status); err != nil {
 		diags = append(diags, diag.FromErr(err)...)
 	}
 	if _, ok := d.GetOk("amazon_eventbridge"); ok {

--- a/internal/provider/resources/resource_webhook_endpoint.go
+++ b/internal/provider/resources/resource_webhook_endpoint.go
@@ -203,7 +203,7 @@ func ResourceWebhookEndpoint() *schema.Resource {
 		DeleteContext: resourceWebhookEndpointDelete,
 
 		Importer: &schema.ResourceImporter{
-			StateContext: schema.ImportStatePassthroughContext,
+			StateContext: resourceWebhookEndpointImportState,
 		},
 	}
 }
@@ -255,6 +255,8 @@ func resourceWebhookEndpointCreate(ctx context.Context, d *schema.ResourceData, 
 
 func resourceWebhookEndpointRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var diags diag.Diagnostics
+	importing := ctx.Value("importing") != nil
+	_ = importing
 	tflog.Debug(ctx, "Reading stripe_webhook_endpoint resource", map[string]interface{}{"id": d.Id()})
 	c := meta.(*stripe.Client)
 
@@ -375,4 +377,13 @@ func resourceWebhookEndpointDelete(ctx context.Context, d *schema.ResourceData, 
 
 	d.SetId("")
 	return nil
+}
+
+func resourceWebhookEndpointImportState(ctx context.Context, d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
+	diags := resourceWebhookEndpointRead(context.WithValue(ctx, "importing", true), d, meta)
+	if diags.HasError() {
+		return nil, fmt.Errorf("%s", diags[0].Summary)
+	}
+
+	return []*schema.ResourceData{d}, nil
 }

--- a/internal/provider/resources/resource_webhook_endpoint.go
+++ b/internal/provider/resources/resource_webhook_endpoint.go
@@ -179,11 +179,21 @@ func ResourceWebhookEndpoint() *schema.Resource {
 				Description: "The URL of the webhook endpoint.",
 				Required:    true,
 			},
+			"application": {
+				Type:        schema.TypeString,
+				Description: "The ID of the associated Connect application.",
+				Computed:    true,
+			},
 			"secret": {
 				Type:        schema.TypeString,
 				Description: "The endpoint's secret, used to generate [webhook signatures](https://docs.stripe.com/webhooks/signatures). Only returned at creation.",
 				Computed:    true,
 				Sensitive:   true,
+			},
+			"status": {
+				Type:        schema.TypeString,
+				Description: "The status of the webhook. It can be `enabled` or `disabled`.",
+				Computed:    true,
 			},
 		},
 
@@ -275,6 +285,12 @@ func resourceWebhookEndpointRead(ctx context.Context, d *schema.ResourceData, me
 		diags = append(diags, diag.FromErr(err)...)
 	}
 	if err := d.Set("url", webhook_endpoint.URL); err != nil {
+		diags = append(diags, diag.FromErr(err)...)
+	}
+	if err := d.Set("application", webhook_endpoint.Application); err != nil {
+		diags = append(diags, diag.FromErr(err)...)
+	}
+	if err := d.Set("status", webhook_endpoint.Status); err != nil {
 		diags = append(diags, diag.FromErr(err)...)
 	}
 	return diags

--- a/modules/token-billing/main.tf
+++ b/modules/token-billing/main.tf
@@ -220,7 +220,7 @@ resource "stripe_v2_billing_service_action" "credit_grant" {
       
       monetary {
         currency = var.currency
-        amount   = var.credit_grant.amount
+        value    = var.credit_grant.amount
       }
     }
     


### PR DESCRIPTION
Fixing issues related to v2 UBB usage. 
- Expose read-only attributes in terraform so that they can be used to build upon (i.e. `latest_version`, `status` etc) 
- Fix `terraform import` ability so that existing resources can be correctly imported
- bump API versions so latest changes are reflected (one field name change from amount -> value) 


Resolves:
- https://jira.corp.stripe.com/browse/TERRAFORM-21
- https://jira.corp.stripe.com/browse/TERRAFORM-22
- https://jira.corp.stripe.com/browse/TERRAFORM-23
- https://jira.corp.stripe.com/browse/TERRAFORM-25
- https://jira.corp.stripe.com/browse/TERRAFORM-26