### PR TITLE
Fix promotion_code customer field type error in Read

### DIFF
--- a/internal/provider/resources/resource_promotion_code.go
+++ b/internal/provider/resources/resource_promotion_code.go
@@ -268,8 +268,10 @@ func resourcePromotionCodeRead(ctx context.Context, d *schema.ResourceData, meta
 	if err := d.Set("code", promotion_code.Code); err != nil {
 		diags = append(diags, diag.FromErr(err)...)
 	}
-	if err := d.Set("customer", promotion_code.Customer); err != nil {
-		diags = append(diags, diag.FromErr(err)...)
+	if promotion_code.Customer != nil {
+		if err := d.Set("customer", promotion_code.Customer.ID); err != nil {
+			diags = append(diags, diag.FromErr(err)...)
+		}
 	}
 	if err := d.Set("customer_account", promotion_code.CustomerAccount); err != nil {
 		diags = append(diags, diag.FromErr(err)...)


### PR DESCRIPTION
## Problem

When creating a `stripe_promotion_code` resource with the `customer` field set, `terraform apply` succeeds but the subsequent Read fails with:

```
customer: '' expected type 'string', got unconvertible type 'stripe.Customer'
```

This happens because `resourcePromotionCodeRead` does:

```go
d.Set("customer", promotion_code.Customer)
```

But `promotion_code.Customer` is `*stripe.Customer` (an expanded struct in the Go SDK), not a `string`. The schema defines `customer` as `TypeString`.

## Fix

Extract the customer ID from the struct:

```go
if promotion_code.Customer != nil {
    d.Set("customer", promotion_code.Customer.ID)
}
```

## Why this wasn't caught earlier

The `customer` field is optional — most promotion codes are not restricted to a specific customer. When `Customer` is nil, `d.Set("customer", nil)` succeeds silently.