### PR TITLE
feat: add unit_amount_decimal to tiers block for stripe_price resource

### DIFF
--- a/docs/resources/price.md
+++ b/docs/resources/price.md
@@ -123,3 +123,4 @@ Optional:
 - `flat_amount` (Number) The flat billing amount for an entire tier, regardless of the number of units in the tier.
 - `flat_amount_decimal` (String) Same as `flat_amount`, but accepts a decimal value representing an integer in the minor units of the currency. Only one of `flat_amount` and `flat_amount_decimal` can be set.
 - `unit_amount` (Number) The per unit billing amount for each individual unit for which this tier applies.
+- `unit_amount_decimal` (String) Same as `unit_amount`, but accepts a decimal value in cents with at most 12 decimal places. Only one of `unit_amount` and `unit_amount_decimal` can be set.

--- a/internal/provider/resources/resource_price.go
+++ b/internal/provider/resources/resource_price.go
@@ -343,7 +343,7 @@ func ResourcePrice() *schema.Resource {
 						},
 						"unit_amount_decimal": {
 							Type:             schema.TypeString,
-							Description:      "Same as `unit_amount`, but accepts a decimal value in cents (or local equivalent) with at most 12 decimal places. Only one of `unit_amount` and `unit_amount_decimal` can be set.",
+							Description:      "Same as `unit_amount`, but accepts a decimal value in cents with at most 12 decimal places. Only one of `unit_amount` and `unit_amount_decimal` can be set.",
 							Optional:         true,
 							DiffSuppressFunc: suppressDecimalDiff,
 						},

--- a/internal/provider/resources/resource_price.go
+++ b/internal/provider/resources/resource_price.go
@@ -341,6 +341,12 @@ func ResourcePrice() *schema.Resource {
 							Description: "The per unit billing amount for each individual unit for which this tier applies.",
 							Optional:    true,
 						},
+						"unit_amount_decimal": {
+							Type:             schema.TypeString,
+							Description:      "Same as `unit_amount`, but accepts a decimal value in cents (or local equivalent) with at most 12 decimal places. Only one of `unit_amount` and `unit_amount_decimal` can be set.",
+							Optional:         true,
+							DiffSuppressFunc: suppressDecimalDiff,
+						},
 						"up_to": {
 							Type:     schema.TypeString,
 							Required: true,
@@ -487,6 +493,11 @@ func resourcePriceCreate(ctx context.Context, d *schema.ResourceData, meta inter
 			}
 			if val, ok := data["unit_amount"].(int); ok {
 				condition.UnitAmount = stripe.Int64(int64(val))
+			}
+			if unit_amount_decimal, ok := data["unit_amount_decimal"].(string); ok && unit_amount_decimal != "" {
+				if f, err := strconv.ParseFloat(unit_amount_decimal, 64); err == nil {
+					condition.UnitAmountDecimal = stripe.Float64(f)
+				}
 			}
 			if up_to, ok := data["up_to"].(string); ok && up_to != "" {
 				if up_to == "inf" {

--- a/internal/provider/resources/resource_price.go
+++ b/internal/provider/resources/resource_price.go
@@ -491,13 +491,12 @@ func resourcePriceCreate(ctx context.Context, d *schema.ResourceData, meta inter
 					condition.FlatAmountDecimal = stripe.Float64(f)
 				}
 			}
-			if val, ok := data["unit_amount"].(int); ok {
-				condition.UnitAmount = stripe.Int64(int64(val))
-			}
 			if unit_amount_decimal, ok := data["unit_amount_decimal"].(string); ok && unit_amount_decimal != "" {
 				if f, err := strconv.ParseFloat(unit_amount_decimal, 64); err == nil {
 					condition.UnitAmountDecimal = stripe.Float64(f)
 				}
+			} else if val, ok := data["unit_amount"].(int); ok {
+				condition.UnitAmount = stripe.Int64(int64(val))
 			}
 			if up_to, ok := data["up_to"].(string); ok && up_to != "" {
 				if up_to == "inf" {


### PR DESCRIPTION
## Issue

Closes #22

## Summary

**What:**

Add `unit_amount_decimal` field to the `tiers` block in the `stripe_price` resource, and fix the mutual exclusion between `unit_amount` and `unit_amount_decimal` to match the [Stripe API contract](https://docs.stripe.com/api/prices/create#create_price-tiers-unit_amount_decimal).

**Why:**

The Stripe API supports `unit_amount_decimal` in tiers for sub-cent per-unit pricing (e.g., \$0.003/minute for compute billing). The Go SDK already has the field on \`PriceCreateTierParams\`. The provider was missing the schema definition and create-path mapping. Additionally, the existing create logic always sent \`unit_amount=0\` even when unset, which conflicts with \`unit_amount_decimal\` (Stripe rejects requests containing both).

**Lines added:** +13

## Changes

Two files, three commits:

### 1. `internal/provider/resources/resource_price.go`

- **Schema** (L344-349): Added `unit_amount_decimal` as `TypeString`, optional, with `suppressDecimalDiff`. Mirrors the existing `flat_amount_decimal` field.
- **Create** (L494-499): Maps `unit_amount_decimal` to `condition.UnitAmountDecimal` via `strconv.ParseFloat`. Made `unit_amount` and `unit_amount_decimal` mutually exclusive: `unit_amount_decimal` is checked first; `unit_amount` is only set in the `else` branch. This matches the Stripe API's "only one of `unit_amount` and `unit_amount_decimal` can be set" constraint.
- **Read**: No change needed. Line 627 already reads `item.UnitAmountDecimal` from the API response. Adding the schema field allows Terraform to persist it (previously silently discarded).

### 2. `docs/resources/price.md`

- Added `unit_amount_decimal` to the tiers nested schema documentation. Description is verbatim from the Stripe API docs.

## Test Plan

Verified end-to-end against the live Stripe test API:

1. `go build ./...` — compiles clean.
2. `terraform plan` — shows `unit_amount_decimal = "0.3"` and `"0.15"` in the tiers. No schema errors.
3. `terraform apply` — successfully creates product, billing meter, and tiered price with sub-cent amounts on Stripe test mode.
4. `terraform plan` (re-run) — **"No changes. Your infrastructure matches the configuration."** Confirms the Read path round-trips `unit_amount_decimal` correctly.

The first apply attempt (before the mutual-exclusion fix) failed with:

```
You may only specify one of these parameters: unit_amount, unit_amount_decimal.
```

This revealed the pre-existing bug where `unit_amount` was always sent as `0` even when not configured, because the Go zero-value `int(0)` always passes the type assertion. Fixed by making the two fields an if/else branch.

## Tests Added

- [ ] Unit tests
- [ ] Integration tests
- [ ] E2E tests
- [x] N/A — the repo has no test infrastructure. Verified manually against the live Stripe test API.

## Documentation

- `docs/resources/price.md`: Added `unit_amount_decimal` to the `tiers` nested schema block. Description matches the Stripe API verbatim.

## Usage

```hcl
resource "stripe_price" "compute_graduated" {
  product        = stripe_product.compute.id
  currency       = "usd"
  billing_scheme = "tiered"
  tiers_mode     = "graduated"

  recurring {
    interval   = "month"
    usage_type = "metered"
    meter      = stripe_billing_meter.compute_minutes.id
  }

  tiers {
    up_to               = "1000"
    unit_amount_decimal = "0.3"   # $0.003/unit
  }

  tiers {
    up_to               = "inf"
    unit_amount_decimal = "0.15"  # $0.0015/unit
  }
}
```