### PR TITLE
Fix missing computed fields in nested blocks

### DIFF
--- a/internal/provider/resources/resource_coupon.go
+++ b/internal/provider/resources/resource_coupon.go
@@ -162,6 +162,11 @@ func ResourceCoupon() *schema.Resource {
 							Required:    true,
 							ForceNew:    true,
 						},
+						"display_name": {
+							Type:        schema.TypeString,
+							Description: "The name of the script used to calculate the discount.",
+							Computed:    true,
+						},
 					},
 				},
 			},

--- a/internal/provider/resources/resource_customer.go
+++ b/internal/provider/resources/resource_customer.go
@@ -191,6 +191,21 @@ func ResourceCustomer() *schema.Resource {
 								},
 							},
 						},
+						"available": {
+							Type:        schema.TypeMap,
+							Description: "A hash of all cash balances available to this customer. You cannot delete a customer with any cash balances, even if the balance is 0. Amounts are represented in the [smallest currency unit](https://stripe.com/docs/currencies#zero-decimal).",
+							Computed:    true,
+						},
+						"customer": {
+							Type:        schema.TypeString,
+							Description: "The ID of the customer whose cash balance this object represents.",
+							Computed:    true,
+						},
+						"customer_account": {
+							Type:        schema.TypeString,
+							Description: "The ID of the account whose cash balance this object represents.",
+							Computed:    true,
+						},
 					},
 				},
 			},
@@ -299,6 +314,16 @@ func ResourceCustomer() *schema.Resource {
 							Description: "Customer phone (including extension).",
 							Optional:    true,
 						},
+						"carrier": {
+							Type:        schema.TypeString,
+							Description: "The delivery service that shipped a physical product, such as Fedex, UPS, USPS, etc.",
+							Computed:    true,
+						},
+						"tracking_number": {
+							Type:        schema.TypeString,
+							Description: "The tracking number for a physical product, obtained from the delivery service. If multiple tracking numbers were generated for this purchase, please separate them with commas.",
+							Computed:    true,
+						},
 					},
 				},
 			},
@@ -321,6 +346,16 @@ func ResourceCustomer() *schema.Resource {
 								"deferred",
 								"immediately",
 							}, false)),
+						},
+						"automatic_tax": {
+							Type:        schema.TypeString,
+							Description: "Surfaces if automatic tax computation is possible given the current customer location information.",
+							Computed:    true,
+						},
+						"provider": {
+							Type:        schema.TypeString,
+							Description: "The tax calculation provider used for location resolution. Defaults to `stripe` when not using a [third-party provider](/tax/third-party-apps).",
+							Computed:    true,
 						},
 					},
 				},
@@ -752,6 +787,9 @@ func resourceCustomerRead(ctx context.Context, d *schema.ResourceData, meta inte
 			}
 			if customer.Tax.Provider != "" {
 				nestedData["provider"] = customer.Tax.Provider
+			}
+			if v, ok := d.GetOk("tax.0.validate_location"); ok {
+				nestedData["validate_location"] = v
 			}
 			if len(nestedData) > 0 {
 				if err := d.Set("tax", []interface{}{nestedData}); err != nil {

--- a/internal/provider/resources/resource_price.go
+++ b/internal/provider/resources/resource_price.go
@@ -591,6 +591,9 @@ func resourcePriceRead(ctx context.Context, d *schema.ResourceData, meta interfa
 			nestedData["maximum"] = int(price.CustomUnitAmount.Maximum)
 			nestedData["minimum"] = int(price.CustomUnitAmount.Minimum)
 			nestedData["preset"] = int(price.CustomUnitAmount.Preset)
+			if v, ok := d.GetOk("custom_unit_amount.0.enabled"); ok {
+				nestedData["enabled"] = v.(bool)
+			}
 			if len(nestedData) > 0 {
 				if err := d.Set("custom_unit_amount", []interface{}{nestedData}); err != nil {
 					diags = append(diags, diag.FromErr(err)...)

--- a/internal/provider/resources/resource_v2_core_event_destination.go
+++ b/internal/provider/resources/resource_v2_core_event_destination.go
@@ -107,6 +107,16 @@ func ResourceV2CoreEventDestination() *schema.Resource {
 							Required:    true,
 							ForceNew:    true,
 						},
+						"aws_event_source_arn": {
+							Type:        schema.TypeString,
+							Description: "The ARN of the AWS event source.",
+							Computed:    true,
+						},
+						"aws_event_source_status": {
+							Type:        schema.TypeString,
+							Description: "The state of the AWS event source.",
+							Computed:    true,
+						},
 					},
 				},
 			},
@@ -121,6 +131,11 @@ func ResourceV2CoreEventDestination() *schema.Resource {
 							Type:        schema.TypeString,
 							Description: "The URL of the webhook endpoint.",
 							Required:    true,
+						},
+						"signing_secret": {
+							Type:        schema.TypeString,
+							Description: "The signing secret of the webhook endpoint, only includable on creation.",
+							Computed:    true,
 						},
 					},
 				},
@@ -270,6 +285,9 @@ func resourceV2CoreEventDestinationRead(ctx context.Context, d *schema.ResourceD
 			nestedData["aws_account_id"] = v2_core_event_destination.AmazonEventbridge.AwsAccountID
 			nestedData["aws_event_source_arn"] = v2_core_event_destination.AmazonEventbridge.AwsEventSourceArn
 			nestedData["aws_event_source_status"] = v2_core_event_destination.AmazonEventbridge.AwsEventSourceStatus
+			if v, ok := d.GetOk("amazon_eventbridge.0.aws_region"); ok {
+				nestedData["aws_region"] = v
+			}
 			if len(nestedData) > 0 {
 				if err := d.Set("amazon_eventbridge", []interface{}{nestedData}); err != nil {
 					diags = append(diags, diag.FromErr(err)...)


### PR DESCRIPTION
This PRs adds the missing computed fields in Nested blocks, most notably fields on the event destination resource. 