### PR TITLE
fix(price): expand tiers when reading prices

### DIFF
--- a/internal/provider/resources/resource_price.go
+++ b/internal/provider/resources/resource_price.go
@@ -546,7 +546,11 @@ func resourcePriceRead(ctx context.Context, d *schema.ResourceData, meta interfa
 	tflog.Debug(ctx, "Reading stripe_price resource", map[string]interface{}{"id": d.Id()})
 	c := meta.(*stripe.Client)
 
-	price, err := c.V1Prices.Retrieve(ctx, d.Id(), nil)
+	price, err := c.V1Prices.Retrieve(ctx, d.Id(), &stripe.PriceRetrieveParams{
+		Params: stripe.Params{
+			Expand: []*string{stripe.String("tiers")},
+		},
+	})
 	if err != nil {
 		// Check if it's a 404 (resource was deleted) vs other errors
 		if stripeErr, ok := err.(*stripe.Error); ok && stripeErr.HTTPStatusCode == 404 {


### PR DESCRIPTION
Summary
- Request `expand[]=tiers` when reading `stripe_price` resources.
- This lets imported or refreshed tiered prices populate the `tiers` state instead of reading an empty tier list.

Context
- Addresses the remaining read/import expand issue from #20.
- The `up_to = "inf"` read handling described in #20 is already present on current `main`, so this PR intentionally keeps the change scoped to the missing expand.

Verification
- `gofmt -w internal/provider/resources/resource_price.go`
- `go test ./...`
- `go test ./internal/provider/resources`
- `git diff --check`