### PR TITLE
fix: missing api version

### DIFF
--- a/internal/provider/resources/resource_webhook_endpoint.go
+++ b/internal/provider/resources/resource_webhook_endpoint.go
@@ -148,6 +148,9 @@ func ResourceWebhookEndpoint() *schema.Resource {
 					"2025-09-30.clover",
 					"2025-10-29.clover",
 					"2025-11-17.clover",
+					"2026-03-25.dahlia",
+					"2026-04-22.dahlia",
+					"2026-05-27.dahlia",
 				}, false)),
 			},
 			"connect": {


### PR DESCRIPTION
## Summary
This fix was introduce by https://github.com/stripe/terraform-provider-stripe/pull/36 already but closed.

- Adds `2026-03-25.dahlia`, `2026-04-22.dahlia`, and `2026-05-27.dahlia` to the `StringInSlice` validator for `stripe_webhook_endpoint.api_version`.
- The validator currently caps at `2025-11-17.clover`, so plan-time validation rejects any Dahlia date before the request reaches Stripe.

## Notes
- No `stripe-go` bump required: `api_version` is a free-form Stripe-Version string, not a typed SDK value.
- The file is marked `DO NOT EDIT` (generator output). Happy to drop this patch if you'd prefer to regenerate from your internal generator — opening it so the gap is on your radar.

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `make test`
- [x] `gofmt -l .` is clean